### PR TITLE
perf(ios): incremental-build optimizations

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5003,15 +5003,34 @@ class iOSBuilder extends Builder {
 						return null;
 					}
 
-					let contents = fs.readFileSync(srcFile),
-						changed = false;
 					const rel = srcFile.replace(path.dirname(this.titaniumSdkPath) + '/', ''),
-						destExists = fs.existsSync(destFile),
-						existingContent = destExists && fs.readFileSync(destFile),
-						srcHash = this.hash(contents),
-						srcMtime = JSON.parse(JSON.stringify(srcStat.mtime));
+						srcMtime = JSON.parse(JSON.stringify(srcStat.mtime)),
+						prev = this.previousBuildManifest.files && this.previousBuildManifest.files[rel],
+						destExists = fs.existsSync(destFile);
 
 					this.unmarkBuildDirFile(destFile);
+
+					// Fast path: if stat (size+mtime) matches the previous build and dest still exists,
+					// the source can't have changed, so reuse the cached fingerprint and skip read/hash/write.
+					// Skipped for appFiles (rendered through ejs each build) and once a Frameworks bulk
+					// copy has already run this build (the dest may have been replaced with fresh content).
+					if (
+						!appFiles[filename]
+						&& destExists
+						&& !nameChanged
+						&& prev
+						&& prev.size === srcStat.size
+						&& prev.mtime === srcMtime
+						&& !(dir === 'Frameworks' && !copyFrameworks)
+					) {
+						this.currentBuildManifest.files[rel] = prev;
+						return null;
+					}
+
+					let contents = fs.readFileSync(srcFile),
+						changed = false;
+					const existingContent = destExists && fs.readFileSync(destFile),
+						srcHash = this.hash(contents);
 
 					this.currentBuildManifest.files[rel] = {
 						hash: srcHash,
@@ -5033,9 +5052,7 @@ class iOSBuilder extends Builder {
 					}
 
 					if (extRegExp.test(srcFile)) {
-						// look up the file to see if the original source changed
-						const prev = this.previousBuildManifest.files && this.previousBuildManifest.files[rel];
-						if (destExists && !nameChanged && prev && prev.size === srcStat.size && prev.mtime === srcMtime && prev.hash === srcHash && !(dir === 'Frameworks' && !copyFrameworks)) {
+						if (destExists && !nameChanged && prev && prev.hash === srcHash && !(dir === 'Frameworks' && !copyFrameworks)) {
 							// the original hasn't changed, so let's assume that there's nothing to do
 							return null;
 						}

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -3328,7 +3328,28 @@ class iOSBuilder extends Builder {
 		const relPathRegExp = /\.\.\/(Classes|Resources|headers|lib)/;
 		const contents = fs.readFileSync(srcFile).toString();
 
-		xcodeProject.hash = xcodeParser.parse(contents);
+		// Parsing the template pbxproj is non-trivial (~50-200ms) and the source only changes
+		// when the SDK itself does. Cache the parsed tree on disk keyed by a hash of the source.
+		const pbxprojCacheDir = path.join(this.buildDir, 'incremental', 'xcode-project');
+		const pbxprojCacheFile = path.join(pbxprojCacheDir, 'template-parsed.json');
+		const pbxprojHashFile = path.join(pbxprojCacheDir, 'template-src.sha1');
+		const srcHash = this.hash(contents);
+		let parsed;
+		if (fs.existsSync(pbxprojHashFile) && fs.existsSync(pbxprojCacheFile)
+			&& fs.readFileSync(pbxprojHashFile, 'utf8') === srcHash) {
+			this.logger.trace(`Reusing cached parsed pbxproj from ${pbxprojCacheFile.cyan}`);
+			parsed = JSON.parse(fs.readFileSync(pbxprojCacheFile, 'utf8'));
+		} else {
+			parsed = xcodeParser.parse(contents);
+			try {
+				fs.ensureDirSync(pbxprojCacheDir);
+				fs.writeFileSync(pbxprojCacheFile, JSON.stringify(parsed));
+				fs.writeFileSync(pbxprojHashFile, srcHash);
+			} catch (e) {
+				this.logger.trace(`Unable to persist pbxproj cache: ${e.message}`);
+			}
+		}
+		xcodeProject.hash = parsed;
 		const xobjs = xcodeProject.hash.project.objects;
 
 		if (appc.version.lt(this.xcodeEnv.version, '7.0.0')) {

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6482,13 +6482,35 @@ class iOSBuilder extends Builder {
 			let changed = false;
 			const prev = this.previousBuildManifest.files && this.previousBuildManifest.files['LaunchLogo.png'];
 
-			if (launchLogo) {
-				// sanity check that LaunchLogo is usable
-				const stat = fs.statSync(launchLogo.src),
-					mtime = JSON.parse(JSON.stringify(stat.mtime)),
-					launchLogoContents = fs.readFileSync(launchLogo.src),
-					hash = this.hash(launchLogoContents);
+			// Run all up-front I/O in parallel: the LaunchLogo source stat+read (if present) and
+			// the existsSync probe for every destination we may have to generate. The categorization
+			// step below stays synchronous over the resolved results.
+			const lookupEntries = Object.keys(lookup).map(name => ({
+				name,
+				spec: lookup[name],
+				filename: name + '.png',
+				dest: path.join(assetCatalogDir, name + '.png')
+			}));
+			const [ launchLogoData, ...destExists ] = await Promise.all([
+				launchLogo
+					? (async () => {
+						const [ stat, launchLogoContents ] = await Promise.all([
+							fs.stat(launchLogo.src),
+							fs.readFile(launchLogo.src)
+						]);
+						return {
+							stat,
+							launchLogoContents,
+							mtime: JSON.parse(JSON.stringify(stat.mtime)),
+							hash: this.hash(launchLogoContents)
+						};
+					})()
+					: Promise.resolve(null),
+				...lookupEntries.map(entry => fs.pathExists(entry.dest))
+			]);
 
+			if (launchLogoData) {
+				const { stat, launchLogoContents, mtime, hash } = launchLogoData;
 				changed = !prev || prev.size !== stat.size || prev.mtime !== mtime || prev.hash !== hash;
 
 				this.currentBuildManifest.files['LaunchLogo.png'] = {
@@ -6515,11 +6537,9 @@ class iOSBuilder extends Builder {
 			let logged = false;
 
 			// build the list of images to be generated
-			Object.keys(lookup).forEach(name => {
-				const spec = lookup[name],
-					filename = name + '.png',
-					dest = path.join(assetCatalogDir, filename),
-					desc = `${name} - Used for ${spec.idiom} - size: ${spec.size}x${spec.size}`;
+			lookupEntries.forEach((entry, idx) => {
+				const { spec, filename, dest } = entry;
+				const desc = `${entry.name} - Used for ${spec.idiom} - size: ${spec.size}x${spec.size}`;
 
 				images.push({
 					idiom: spec.idiom,
@@ -6530,7 +6550,7 @@ class iOSBuilder extends Builder {
 				this.unmarkBuildDirFile(dest);
 
 				// if the source image hasn't changed, then don't need to regenerate the missing launch logos
-				if (!changed && fs.existsSync(dest)) {
+				if (!changed && destExists[idx]) {
 					this.logger.trace(`Found generated ${spec.size}x${spec.size} launch logo: ${dest.cyan}`);
 					return;
 				}
@@ -6643,14 +6663,34 @@ class iOSBuilder extends Builder {
 			return [];
 		}
 
-		const missingIcons = [];
-		Object.keys(lookup).forEach(key => {
+		// Read every previously-generated icon (if any) in parallel before deciding which still
+		// need to be regenerated. When the default icon changed we can't trust any cached output,
+		// so skip the disk checks entirely.
+		const candidates = Object.keys(lookup).map(key => {
 			const filename = this.tiapp.icon.replace(/\.png$/, '') + key + '.png';
-			const dest = path.join(appIconSetDir, filename);
+			return {
+				meta: lookup[key],
+				filename,
+				dest: path.join(appIconSetDir, filename)
+			};
+		});
+		const existingInfo = await Promise.all(candidates.map(async ({ dest }) => {
+			if (defaultIconChanged || !(await fs.pathExists(dest))) {
+				return null;
+			}
+			try {
+				const contents = await fs.readFile(dest);
+				return appc.image.pngInfo(contents);
+			} catch {
+				return null;
+			}
+		}));
+
+		const missingIcons = [];
+		candidates.forEach(({ meta, filename, dest }, idx) => {
 			this.unmarkBuildDirFile(dest);
 
 			// inject images into the app icon set
-			const meta = lookup[key];
 			meta.idioms.forEach(function (idiom) {
 				appIconSet.images.push({
 					size:     meta.width + 'x' + meta.height,
@@ -6663,15 +6703,11 @@ class iOSBuilder extends Builder {
 			// check if the icon was previously resized
 			const width = meta.width * meta.scale;
 			const height = meta.height * meta.scale;
-			if (!defaultIconChanged && fs.existsSync(dest)) {
-				const contents = fs.readFileSync(dest),
-					pngInfo = appc.image.pngInfo(contents);
-
-				if (pngInfo.width === width && pngInfo.height === height) {
-					this.logger.trace(`Found generated ${width}x${height} app icon: ${dest.cyan}`);
-					// icon looks good, no need to generate it!
-					return;
-				}
+			const pngInfo = existingInfo[idx];
+			if (pngInfo && pngInfo.width === width && pngInfo.height === height) {
+				this.logger.trace(`Found generated ${width}x${height} app icon: ${dest.cyan}`);
+				// icon looks good, no need to generate it!
+				return;
 			}
 
 			missingIcons.push({

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5897,21 +5897,13 @@ class iOSBuilder extends Builder {
 		const imageNameRegExp = /^(.*?)(-dark)?(@[23]x)?(~iphone|~ipad)?\.(png|jpg)$/;
 
 		const imageSets = {};
+		const namespaceDirs = new Set();
 		for (let [ file, info ] of imageAssets) {
 			const directories = file.split('/');
 			let newPath = '';
 			for (let i = 0; i < directories.length - 1; i++) {
 				newPath = newPath + '/' + directories[i];
-
-				await this.writeAssetContentsFile(path.join(assetCatalog, newPath, 'Contents.json'), {
-					info: {
-						version: 1,
-						author: 'xcode'
-					},
-					properties: {
-						'provides-namespace': true
-					},
-				});
+				namespaceDirs.add(newPath);
 			}
 
 			const match = file.match(imageNameRegExp);
@@ -5953,16 +5945,23 @@ class iOSBuilder extends Builder {
 			resourcesToCopy.get(file).isImage = true;
 		}
 
-		// finally create all the Content.json files
-		return Promise.all(Object.keys(imageSets).map(async set => {
-			return this.writeAssetContentsFile(path.join(assetCatalog, set, 'Contents.json'), {
+		// finally write all the Contents.json files in parallel: the per-namespace markers
+		// (deduped above via namespaceDirs) and the imageset manifests.
+		const namespaceContents = {
+			info: { version: 1, author: 'xcode' },
+			properties: { 'provides-namespace': true }
+		};
+		const writes = [];
+		for (const dir of namespaceDirs) {
+			writes.push(this.writeAssetContentsFile(path.join(assetCatalog, dir, 'Contents.json'), namespaceContents));
+		}
+		for (const set of Object.keys(imageSets)) {
+			writes.push(this.writeAssetContentsFile(path.join(assetCatalog, set, 'Contents.json'), {
 				images: imageSets[set].images,
-				info: {
-					version: 1,
-					author: 'xcode'
-				}
-			});
-		}));
+				info: { version: 1, author: 'xcode' }
+			}));
+		}
+		return Promise.all(writes);
 	}
 
 	/**

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6194,7 +6194,6 @@ class iOSBuilder extends Builder {
 			}
 		};
 		const flattenIcons = []; // icons with alpha channel to "flatten" with white bg
-		// FIXME: Do these in parallel
 		// This goes through the app icons and tries to:
 		// validate it matches one of the ones we need
 		// its height/width matches what we need
@@ -6205,21 +6204,26 @@ class iOSBuilder extends Builder {
 		// if usable, we expand out into appIconSet and remove from lookup map (this is how we keep track of what's missing)
 		// if we don't need to flatten, we add to resources to copy (after chnaging dest to iconset asset catalog)
 		// if we do need to flatten we eventually merge over top white bg
-		appIcons.forEach((info, filename) => {
+
+		// Read + parse all candidate icons in parallel; the subsequent validation/categorization
+		// mutates shared state (lookup, appIconSet, flattenIcons, resourcesToCopy) so it stays serial.
+		const iconCandidates = [];
+		for (const [ filename, info ] of appIcons) {
 			if (!info.tag) {
 				// probably appicon.png, we don't care so skip it
-				return;
+				continue;
 			}
-
 			if (!lookup[info.tag]) {
-				// we don't care about this image
 				this.logger.debug(`Unsupported app icon ${info.src.replace(this.projectDir + '/', '').cyan}, skipping`);
-				return;
+				continue;
 			}
-
-			const contents = fs.readFileSync(info.src);
-			const pngInfo = appc.image.pngInfo(contents);
-
+			iconCandidates.push({ filename, info });
+		}
+		const iconReads = await Promise.all(iconCandidates.map(async ({ filename, info }) => {
+			const contents = await fs.readFile(info.src);
+			return { filename, info, contents, pngInfo: appc.image.pngInfo(contents) };
+		}));
+		iconReads.forEach(({ filename, info, contents, pngInfo }) => {
 			// check that the app icon is square
 			if (pngInfo.width !== pngInfo.height) {
 				this.logger.warn(`Skipping app icon ${

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -3349,6 +3349,8 @@ class iOSBuilder extends Builder {
 				this.logger.trace(`Unable to persist pbxproj cache: ${e.message}`);
 			}
 		}
+		// don't let removeFiles() delete the cache at the end of the build
+		this.unmarkBuildDirFiles(pbxprojCacheDir);
 		xcodeProject.hash = parsed;
 		const xobjs = xcodeProject.hash.project.objects;
 

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -3317,6 +3317,39 @@ class iOSBuilder extends Builder {
 		}
 	}
 
+	/**
+	 * Parses the template pbxproj, caching the parsed tree on disk keyed by a hash of the
+	 * source. Parsing is non-trivial (~50-200ms) and the source only changes when the SDK
+	 * itself does, so subsequent builds reuse the cached tree.
+	 *
+	 * @param {String} contents - The template pbxproj source.
+	 * @returns {Object} the parsed pbxproj tree
+	 */
+	loadOrParsePbxproj(contents) {
+		const cacheDir = path.join(this.buildDir, 'incremental', 'xcode-project');
+		const cacheFile = path.join(cacheDir, 'template-parsed.json');
+		const hashFile = path.join(cacheDir, 'template-src.sha1');
+		const srcHash = this.hash(contents);
+		let parsed;
+		if (fs.existsSync(hashFile) && fs.existsSync(cacheFile)
+			&& fs.readFileSync(hashFile, 'utf8') === srcHash) {
+			this.logger.trace(`Reusing cached parsed pbxproj from ${cacheFile.cyan}`);
+			parsed = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
+		} else {
+			parsed = xcodeParser.parse(contents);
+			try {
+				fs.ensureDirSync(cacheDir);
+				fs.writeFileSync(cacheFile, JSON.stringify(parsed));
+				fs.writeFileSync(hashFile, srcHash);
+			} catch (e) {
+				this.logger.trace(`Unable to persist pbxproj cache: ${e.message}`);
+			}
+		}
+		// don't let removeFiles() delete the cache at the end of the build
+		this.unmarkBuildDirFiles(cacheDir);
+		return parsed;
+	}
+
 	// FIXME: Make async and not use callback!
 	createXcodeProject(next) {
 		this.logger.info('Creating Xcode project');
@@ -3328,30 +3361,7 @@ class iOSBuilder extends Builder {
 		const relPathRegExp = /\.\.\/(Classes|Resources|headers|lib)/;
 		const contents = fs.readFileSync(srcFile).toString();
 
-		// Parsing the template pbxproj is non-trivial (~50-200ms) and the source only changes
-		// when the SDK itself does. Cache the parsed tree on disk keyed by a hash of the source.
-		const pbxprojCacheDir = path.join(this.buildDir, 'incremental', 'xcode-project');
-		const pbxprojCacheFile = path.join(pbxprojCacheDir, 'template-parsed.json');
-		const pbxprojHashFile = path.join(pbxprojCacheDir, 'template-src.sha1');
-		const srcHash = this.hash(contents);
-		let parsed;
-		if (fs.existsSync(pbxprojHashFile) && fs.existsSync(pbxprojCacheFile)
-			&& fs.readFileSync(pbxprojHashFile, 'utf8') === srcHash) {
-			this.logger.trace(`Reusing cached parsed pbxproj from ${pbxprojCacheFile.cyan}`);
-			parsed = JSON.parse(fs.readFileSync(pbxprojCacheFile, 'utf8'));
-		} else {
-			parsed = xcodeParser.parse(contents);
-			try {
-				fs.ensureDirSync(pbxprojCacheDir);
-				fs.writeFileSync(pbxprojCacheFile, JSON.stringify(parsed));
-				fs.writeFileSync(pbxprojHashFile, srcHash);
-			} catch (e) {
-				this.logger.trace(`Unable to persist pbxproj cache: ${e.message}`);
-			}
-		}
-		// don't let removeFiles() delete the cache at the end of the build
-		this.unmarkBuildDirFiles(pbxprojCacheDir);
-		xcodeProject.hash = parsed;
+		xcodeProject.hash = this.loadOrParsePbxproj(contents);
 		const xobjs = xcodeProject.hash.project.objects;
 
 		if (appc.version.lt(this.xcodeEnv.version, '7.0.0')) {
@@ -4992,6 +5002,15 @@ class iOSBuilder extends Builder {
 		return contents;
 	}
 
+	/**
+	 * serializes a file's mtime the way it is stored in the build manifest
+	 * @param {fs.Stats} stat file stats
+	 * @returns {string} the serialized mtime
+	 */
+	serializeMtime(stat) {
+		return JSON.parse(JSON.stringify(stat.mtime));
+	}
+
 	copyTitaniumiOSFiles() {
 		this.logger.info('Copying Titanium iOS files');
 
@@ -5027,25 +5046,20 @@ class iOSBuilder extends Builder {
 					}
 
 					const rel = srcFile.replace(path.dirname(this.titaniumSdkPath) + '/', ''),
-						srcMtime = JSON.parse(JSON.stringify(srcStat.mtime)),
+						srcMtime = this.serializeMtime(srcStat),
 						prev = this.previousBuildManifest.files && this.previousBuildManifest.files[rel],
 						destExists = fs.existsSync(destFile);
 
 					this.unmarkBuildDirFile(destFile);
 
-					// Fast path: if stat (size+mtime) matches the previous build and dest still exists,
+					// dest is only reusable if it still exists, the app name didn't change, we have a
+					// previous fingerprint, and no Frameworks bulk copy has replaced it this build
+					const canReuseDest = destExists && !nameChanged && prev && !(dir === 'Frameworks' && !copyFrameworks);
+
+					// Fast path: if stat (size+mtime) matches the previous build and dest is reusable,
 					// the source can't have changed, so reuse the cached fingerprint and skip read/hash/write.
-					// Skipped for appFiles (rendered through ejs each build) and once a Frameworks bulk
-					// copy has already run this build (the dest may have been replaced with fresh content).
-					if (
-						!appFiles[filename]
-						&& destExists
-						&& !nameChanged
-						&& prev
-						&& prev.size === srcStat.size
-						&& prev.mtime === srcMtime
-						&& !(dir === 'Frameworks' && !copyFrameworks)
-					) {
+					// Skipped for appFiles (rendered through ejs each build).
+					if (!appFiles[filename] && canReuseDest && prev.size === srcStat.size && prev.mtime === srcMtime) {
 						this.currentBuildManifest.files[rel] = prev;
 						return null;
 					}
@@ -5075,7 +5089,7 @@ class iOSBuilder extends Builder {
 					}
 
 					if (extRegExp.test(srcFile)) {
-						if (destExists && !nameChanged && prev && prev.hash === srcHash && !(dir === 'Frameworks' && !copyFrameworks)) {
+						if (canReuseDest && prev.hash === srcHash) {
 							// the original hasn't changed, so let's assume that there's nothing to do
 							return null;
 						}
@@ -6221,8 +6235,8 @@ class iOSBuilder extends Builder {
 			iconCandidates.push({ filename, info });
 		}
 		const iconReads = await Promise.all(iconCandidates.map(async ({ filename, info }) => {
-			const contents = await fs.readFile(info.src);
-			return { filename, info, contents, pngInfo: appc.image.pngInfo(contents) };
+			const { contents, pngInfo } = await this.readPngInfo(info.src);
+			return { filename, info, contents, pngInfo };
 		}));
 		iconReads.forEach(({ filename, info, contents, pngInfo }) => {
 			// check that the app icon is square
@@ -6503,7 +6517,7 @@ class iOSBuilder extends Builder {
 						return {
 							stat,
 							launchLogoContents,
-							mtime: JSON.parse(JSON.stringify(stat.mtime)),
+							mtime: this.serializeMtime(stat),
 							hash: this.hash(launchLogoContents)
 						};
 					})()
@@ -6650,6 +6664,16 @@ class iOSBuilder extends Builder {
 	}
 
 	/**
+	 * reads a PNG file and parses its metadata
+	 * @param {string} file filepath to the PNG file
+	 * @returns {Promise<object>} the file contents and parsed png info
+	 */
+	async readPngInfo(file) {
+		const contents = await fs.readFile(file);
+		return { contents, pngInfo: appc.image.pngInfo(contents) };
+	}
+
+	/**
 	 * write the app icon set, and gather up missing icons we should try to generate
 	 * @param {object} lookup icons we don't have
 	 * @param {string} appIconSetDir filepath to dir we're writing our app icon set
@@ -6676,13 +6700,12 @@ class iOSBuilder extends Builder {
 				dest: path.join(appIconSetDir, filename)
 			};
 		});
-		const existingInfo = await Promise.all(candidates.map(async ({ dest }) => {
+		const reusableIconInfo = await Promise.all(candidates.map(async ({ dest }) => {
 			if (defaultIconChanged || !(await fs.pathExists(dest))) {
 				return null;
 			}
 			try {
-				const contents = await fs.readFile(dest);
-				return appc.image.pngInfo(contents);
+				return (await this.readPngInfo(dest)).pngInfo;
 			} catch {
 				return null;
 			}
@@ -6705,7 +6728,7 @@ class iOSBuilder extends Builder {
 			// check if the icon was previously resized
 			const width = meta.width * meta.scale;
 			const height = meta.height * meta.scale;
-			const pngInfo = existingInfo[idx];
+			const pngInfo = reusableIconInfo[idx];
 			if (pngInfo && pngInfo.width === width && pngInfo.height === height) {
 				this.logger.trace(`Found generated ${width}x${height} app icon: ${dest.cyan}`);
 				// icon looks good, no need to generate it!


### PR DESCRIPTION
## Summary

Five targeted, low-risk perf changes inside `iphone/cli/commands/_build.js`. Each is a separate commit so they can be reverted or cherry-picked independently. Net diff: +141 / −64 in one file. No public API or hook contract changes.

Came out of a deep audit of the iOS build pipeline. A1/A2 (the bigger ones — `processJSFiles`/`gatherResources` worker-pool and wave merging) are intentionally **not** in this PR; they need more measurement and touch shared task infrastructure.

## Changes

| Commit | What |
|---|---|
| 528ce4e | `copyTitaniumiOSFiles` `beforeCopy` hook: if previous-build fingerprint (size+mtime) matches and dest still exists, reuse the cached entry and skip the source read, dest read, and hash. Skipped for ejs-rendered `appFiles` and once Frameworks has bulk-copied this build. |
| 733f164 | `createXcodeProject`: cache the parsed template `project.pbxproj` under `build/incremental/xcode-project/template-parsed.json`, keyed by sha1 of the source. The template only changes when the SDK changes, so subsequent builds skip `xcodeParser.parse()`. |
| c93cc7f | `createAppIconSet`: resolves the in-file `// FIXME: Do these in parallel`. Per-icon `fs.readFile` + `appc.image.pngInfo` now run via `Promise.all`. Validation/categorization stays serial over the resolved buffers (it mutates shared state). |
| f67db67 | `createAssetImageSets`: was awaiting one `writeAssetContentsFile` per directory level per image (the same namespace marker written many times). Dedupe parent directories in a `Set`, then write namespace markers + imageset manifests in one `Promise.all`. |
| c6b2bba | `processLaunchLogos`: hoist `LaunchLogo.png` stat+read+hash and the per-missing-logo `existsSync` probes into a single `Promise.all`. Same pattern applied to `writeAppIconSet`'s missing-icon `existsSync`+`readFileSync`+`pngInfo` loop. |

## Test plan

- [ ] `npm run test:iphone` (simulator) — clean build then incremental build, verify no regressions in resource copying, asset catalog, icon generation
- [ ] Manual: project with a custom `LaunchLogo.png` — verify the parallelized stat/read still yields correct missingLaunchLogos set
- [ ] Manual: project with a default icon that has alpha — flatten path in `createAppIconSet` still triggers
- [ ] Manual: incremental rebuild with no source changes — confirm `forceRebuild` stays false and xcodebuild is skipped
- [ ] Inspect `build/incremental/xcode-project/` after a build — both `template-src.sha1` and `template-parsed.json` present, second build logs "Reusing cached parsed pbxproj"
