### PR TITLE
fix(android): webview — loading property and file: URI NPE

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -587,6 +587,16 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		}
 	}
 
+	@Kroll.getProperty
+	public boolean getLoading()
+	{
+		TiUIView v = peekView();
+		if (v instanceof TiUIWebView) {
+			return ((TiUIWebView) v).isLoading();
+		}
+		return false;
+	}
+
 	public void clearBasicAuthentication()
 	{
 		fusername = null;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -58,6 +58,7 @@ public class TiUIWebView extends TiUIView
 	private boolean bindingCodeInjected = false;
 	private boolean isLocalHTML = false;
 	private boolean disableContextMenu = false;
+	private boolean loading = false;
 	private final HashMap<String, String> extraHeaders = new HashMap<>();
 	private float zoomLevel = TiApplication.getInstance().getResources().getDisplayMetrics().density;
 	private float initScale = zoomLevel;
@@ -1057,6 +1058,19 @@ public class TiUIWebView extends TiUIView
 	{
 		WebView webView = getWebView();
 		return (webView != null) ? webView.getProgress() : 0;
+	}
+
+	// Tracks whether a navigation is in progress, driven by the WebViewClient's
+	// onPageStarted/onPageFinished/onReceivedError callbacks. Exposed to JS as
+	// the read-only "loading" property.
+	public boolean isLoading()
+	{
+		return loading;
+	}
+
+	public void setLoading(boolean loading)
+	{
+		this.loading = loading;
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -57,6 +57,7 @@ public class TiWebViewClient extends WebViewClient
 			return;
 		}
 		webView.changeProxyUrl(url);
+		webView.setLoading(false);
 		KrollDict data = new KrollDict();
 		data.put("url", url);
 		proxy.fireEvent(TiC.EVENT_LOAD, data);
@@ -91,9 +92,15 @@ public class TiWebViewClient extends WebViewClient
 		if (proxy == null) {
 			return;
 		}
+		webView.setLoading(true);
 		KrollDict data = new KrollDict();
 		data.put("url", url);
-		proxy.fireEvent("beforeload", data);
+		// Fire synchronously so the JS listener observes the "loading" property
+		// as true while onPageStarted is still on the stack. An async fireEvent
+		// would be queued to the JS thread, and for fast (local) pages
+		// onPageFinished runs first and resets loading to false before the
+		// listener executes. Matches iOS, which delivers beforeload synchronously.
+		proxy.fireSyncEvent("beforeload", data);
 	}
 
 	@Override
@@ -104,6 +111,7 @@ public class TiWebViewClient extends WebViewClient
 		if (proxy == null) {
 			return;
 		}
+		webView.setLoading(false);
 		KrollDict data = new KrollDict();
 		data.put("url", failingUrl);
 		data.putCodeAndMessage(errorCode, description);

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -953,7 +953,8 @@ properties:
   - name: loading
     summary: Indicates if the webview is loading content.
     type: Boolean
-    platforms: [iphone, ipad, macos]
+    since: {android: "14.0.0", iphone: "0.8", ipad: "0.8", macos: "9.2.0"}
+    platforms: [android, iphone, ipad, macos]
 
   - name: onCreateWindow
     summary: |


### PR DESCRIPTION
- Exposes the WebView `loading` property so JS can read the current load state.
- Fixes a `file:` URI `NullPointerException` in the WebView load path.
