### PR TITLE
fix(android): scrollview defaults/zoomScale and ScrollableView isScrolling latch

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollViewProxy.java
@@ -29,7 +29,12 @@ import ti.modules.titanium.ui.widget.TiUIScrollView;
 		TiC.PROPERTY_CONTENT_OFFSET,
 		TiC.PROPERTY_CAN_CANCEL_EVENTS,
 		TiC.PROPERTY_OVER_SCROLL_MODE,
-		TiC.PROPERTY_REFRESH_CONTROL
+		TiC.PROPERTY_REFRESH_CONTROL,
+		"decelerationRate",
+		"disableBounce",
+		"horizontalBounce",
+		"scrollIndicatorStyle",
+		"verticalBounce"
 	})
 public class ScrollViewProxy extends TiViewProxy
 {
@@ -44,6 +49,32 @@ public class ScrollViewProxy extends TiViewProxy
 		offset.put(TiC.EVENT_PROPERTY_X, 0);
 		offset.put(TiC.EVENT_PROPERTY_Y, 0);
 		defaultValues.put(TiC.PROPERTY_CONTENT_OFFSET, offset);
+		defaultValues.put(TiC.PROPERTY_CAN_CANCEL_EVENTS, true);
+		defaultValues.put(TiC.PROPERTY_CONTENT_HEIGHT, "");
+		defaultValues.put(TiC.PROPERTY_CONTENT_WIDTH, "");
+		defaultValues.put(TiC.PROPERTY_SHOW_HORIZONTAL_SCROLL_INDICATOR, false);
+		defaultValues.put(TiC.PROPERTY_SHOW_VERTICAL_SCROLL_INDICATOR, false);
+		defaultValues.put("decelerationRate", 0);
+		defaultValues.put("disableBounce", false);
+		defaultValues.put("horizontalBounce", false);
+		defaultValues.put("scrollIndicatorStyle", 0);
+		defaultValues.put("verticalBounce", false);
+	}
+
+	@Kroll.getProperty
+	public double getZoomScale()
+	{
+		Object value = getProperty("zoomScale");
+		if (value instanceof Number) {
+			return ((Number) value).doubleValue();
+		}
+		return 1.0;
+	}
+
+	@Kroll.method
+	public void setZoomScale(double scale, @Kroll.argument(optional = true) KrollDict options)
+	{
+		setProperty("zoomScale", scale);
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
@@ -123,7 +123,7 @@ public class ScrollableViewProxy extends TiViewProxy
 	{
 		for (final TiViewProxy view : this.views) {
 			view.releaseViews();
-			view.setParent(null);
+			view.setParentInternal(null);
 		}
 		this.views.clear();
 
@@ -156,7 +156,7 @@ public class ScrollableViewProxy extends TiViewProxy
 				if (nextObject instanceof TiViewProxy view) {
 					if (!this.views.contains(view)) {
 						view.setActivity(getActivity());
-						view.setParent(this);
+						view.setParentInternal(this);
 						this.views.add(view);
 					}
 				}
@@ -168,7 +168,7 @@ public class ScrollableViewProxy extends TiViewProxy
 		for (TiViewProxy oldView : oldViewList) {
 			if (!this.views.contains(oldView)) {
 				oldView.releaseViews();
-				oldView.setParent(null);
+				oldView.setParentInternal(null);
 			}
 		}
 
@@ -193,7 +193,7 @@ public class ScrollableViewProxy extends TiViewProxy
 
 		// Add given view to collection.
 		view.setActivity(getActivity());
-		view.setParent(this);
+		view.setParentInternal(this);
 		this.views.add(view);
 
 		// Notify native scrollable view about the added child view.
@@ -209,7 +209,7 @@ public class ScrollableViewProxy extends TiViewProxy
 
 			if (!this.views.contains(view)) {
 				view.setActivity(getActivity());
-				view.setParent(this);
+				view.setParentInternal(this);
 				this.views.add(insertIndex, view);
 			}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
@@ -123,7 +123,7 @@ public class ScrollableViewProxy extends TiViewProxy
 	{
 		for (final TiViewProxy view : this.views) {
 			view.releaseViews();
-			view.setParentInternal(null);
+			view.setParent(null);
 		}
 		this.views.clear();
 
@@ -156,7 +156,7 @@ public class ScrollableViewProxy extends TiViewProxy
 				if (nextObject instanceof TiViewProxy view) {
 					if (!this.views.contains(view)) {
 						view.setActivity(getActivity());
-						view.setParentInternal(this);
+						view.setParent(this);
 						this.views.add(view);
 					}
 				}
@@ -168,7 +168,7 @@ public class ScrollableViewProxy extends TiViewProxy
 		for (TiViewProxy oldView : oldViewList) {
 			if (!this.views.contains(oldView)) {
 				oldView.releaseViews();
-				oldView.setParentInternal(null);
+				oldView.setParent(null);
 			}
 		}
 
@@ -193,7 +193,7 @@ public class ScrollableViewProxy extends TiViewProxy
 
 		// Add given view to collection.
 		view.setActivity(getActivity());
-		view.setParentInternal(this);
+		view.setParent(this);
 		this.views.add(view);
 
 		// Notify native scrollable view about the added child view.
@@ -209,7 +209,7 @@ public class ScrollableViewProxy extends TiViewProxy
 
 			if (!this.views.contains(view)) {
 				view.setActivity(getActivity());
-				view.setParentInternal(this);
+				view.setParent(this);
 				this.views.add(insertIndex, view);
 			}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -102,6 +102,13 @@ public class TiUIScrollableView extends TiUIView
 			public void onPageScrollStateChanged(int scrollState)
 			{
 				switch (scrollState) {
+					case ViewPager2.SCROLL_STATE_SETTLING: {
+						// Programmatic smooth scroll (moveNext/movePrevious/scrollToView).
+						// Latch isScrolling so SCROLL_STATE_IDLE fires scrollend even
+						// when onPageScrolled never samples a non-zero offset (short/fast scrolls).
+						this.isScrolling = true;
+						break;
+					}
 					case ViewPager2.SCROLL_STATE_DRAGGING: {
 						if (!this.isDragging && !getViews().isEmpty()) {
 							// This is the start of a touch/drag event by the end-user. Fire a "dragstart" event.


### PR DESCRIPTION
This PR https://github.com/tidev/titanium-sdk/pull/14524 has to be merged in advance

- `ScrollViewProxy`: add missing property defaults and `zoomScale` support.
- `TiUIScrollableView`: latch `isScrolling` on `SCROLL_STATE_SETTLING` so scroll-end events fire reliably.
- `ScrollableViewProxy`: expose missing properties from the missing-properties batch.