### PR TITLE
chore: unify yauzl versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "temp": "0.9.4",
         "wrap-ansi": "9.0.2",
         "xcode": "3.0.1",
-        "yauzl": "3.2.0"
+        "yauzl": "3.4.0"
       },
       "devDependencies": {
         "@commitlint/cli": "20.1.0",
@@ -72,7 +72,7 @@
         "ssri": "8.0.1",
         "stream-splitter": "0.3.2",
         "strip-ansi": "7.1.2",
-        "titanium": "8.1.5",
+        "titanium": "9.0.0",
         "titanium-docgen": "5.0.0"
       }
     },
@@ -4608,14 +4608,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
@@ -6764,15 +6756,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/fields": {
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/fields/-/fields-0.1.24.tgz",
@@ -7221,9 +7204,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10748,16 +10731,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-appc/node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -11134,16 +11107,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/node-titanium-sdk/node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/node-uuid": {
@@ -14628,32 +14591,32 @@
       }
     },
     "node_modules/titanium": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/titanium/-/titanium-8.1.5.tgz",
-      "integrity": "sha512-AFAoLXHQ36AdIS29oHYtUtTGe9gnM3irg9YOJdsQBsPpZ3jCIA2s7seJDXHjGoN3frPvvPDvZlnZjW3SS0xLUA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/titanium/-/titanium-9.0.0.tgz",
+      "integrity": "sha512-Yk0xbcZYRC8UhsxilpUHfx0g+l4u89b07QK8KCT2bWL1LnEzebCaRq06H2gJmYcsraOYh1XTh95yXhFU3oq8Jg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@xmldom/xmldom": "0.9.8",
+        "@xmldom/xmldom": "0.9.10",
         "chalk": "5.6.2",
-        "commander": "14.0.2",
+        "commander": "15.0.0",
         "execa": "9.6.1",
-        "fs-extra": "11.3.3",
+        "fs-extra": "11.3.5",
         "pretty-bytes": "7.1.0",
         "prompts": "2.4.2",
-        "semver": "7.7.3",
-        "undici": "7.19.2",
-        "which": "6.0.0",
-        "wrap-ansi": "9.0.2",
+        "semver": "7.8.4",
+        "undici": "8.5.0",
+        "which": "7.0.0",
+        "wrap-ansi": "10.0.0",
         "xpath": "0.0.34",
-        "yauzl": "3.2.0"
+        "yauzl": "3.4.0"
       },
       "bin": {
         "ti": "bin/ti.js",
         "titanium": "bin/ti.js"
       },
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/titanium-docgen": {
@@ -14696,14 +14659,17 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/titanium/node_modules/@xmldom/xmldom": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
-      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+    "node_modules/titanium/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/titanium/node_modules/chalk": {
@@ -14720,19 +14686,19 @@
       }
     },
     "node_modules/titanium/node_modules/commander": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/titanium/node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14745,29 +14711,77 @@
       }
     },
     "node_modules/titanium/node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/titanium/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/titanium/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/titanium/node_modules/which": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
-      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
+      "integrity": "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^4.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/titanium/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/tmp": {
@@ -15136,13 +15150,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.2.tgz",
-      "integrity": "sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -15772,12 +15786,11 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
         "pend": "~1.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "temp": "0.9.4",
     "wrap-ansi": "9.0.2",
     "xcode": "3.0.1",
-    "yauzl": "3.2.0"
+    "yauzl": "3.4.0"
   },
   "devDependencies": {
     "@commitlint/cli": "20.1.0",
@@ -154,8 +154,11 @@
     "ssri": "8.0.1",
     "stream-splitter": "0.3.2",
     "strip-ansi": "7.1.2",
-    "titanium": "8.1.5",
+    "titanium": "9.0.0",
     "titanium-docgen": "5.0.0"
+  },
+  "overrides": {
+    "yauzl": "3.4.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixing #14539 

In some folders where I've placed a module zip (e.g. ti.animation) I've got this error when running a build:

```
Titanium Command-Line Interface v8.1.5 SDK v13.2.0.GA
Copyright TiDev, Inc. 4/7/2022-Present. All Rights Reserved.

Please star us on GitHub! https://github.com/tidev/titanium-cli
and https://github.com/tidev/titanium-sdk

Want to help? https://tidev.io/donate or https://tidev.io/contribute

Warning: Detected unsettled top-level await at file:///usr/local/lib/node_modules/titanium/src/main.js:8
	await cli.go();
	^
```

normally it would extract the module, install it and build the app.

The issue is:
> On Node 24, that yauzl version deterministically stalls mid-stream on large compressed entries — no error, the read stream just stops delivering data (I reproduced it: the Lottie framework binary always truncates at 1,993,744 of 2,238,520 bytes). The pending promise never settles, the event loop drains, and Node exits with that unsettled top-level await warning, leaving a half-extracted module and the zip still in place — which is why every build retried and died the same way. yauzl 2.10.0 broken, 3.2.0 broken, 3.4.0 works — it's an upstream yauzl bug fixed between 3.2 and 3.4.

This PR will override all our yauzl version with 3.4.0 until we've upgrade all of our packages to use a higher version

```bash
$ npm ls yauzl
├─┬ node-appc@1.1.7
│ └── yauzl@3.4.0 deduped
├─┬ node-titanium-sdk@6.1.0
│ └─┬ node-appc@1.1.6
│   └── yauzl@3.4.0 deduped
├─┬ titanium@9.0.0
│ └── yauzl@3.4.0 deduped
└── yauzl@3.4.0 overridden
```