### PR TITLE
[14538] fix(ios): prevent Kroll reentrancy crash

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -13,18 +13,21 @@
 #import "TiUtils.h"
 
 #import "TiExceptionHandler.h"
+#include <pthread.h>
 
 static unsigned short KrollContextCount = 0;
 
-static dispatch_queue_t krollEntryQueue;
-static void *krollEntryQueueKey = &krollEntryQueueKey;
+static pthread_mutex_t KrollEntryLock;
 
+// Nested main run loops can re-enter Kroll on the owning thread under a different
+// dispatch queue identity, so Kroll entry must be recursive by thread.
 static inline void KrollEntryLockPerform(dispatch_block_t block)
 {
-  if (dispatch_get_specific(krollEntryQueueKey) == krollEntryQueueKey) {
-    block(); // Already on this queue — re-entrant call
-  } else {
-    dispatch_sync(krollEntryQueue, block);
+  pthread_mutex_lock(&KrollEntryLock);
+  @try {
+    block();
+  } @finally {
+    pthread_mutex_unlock(&KrollEntryLock);
   }
 }
 
@@ -597,8 +600,11 @@ static JSValueRef StringFormatDecimalCallback(JSContextRef jsContext, JSObjectRe
 + (void)initialize
 {
   if (self == [KrollContext class]) {
-    krollEntryQueue = dispatch_queue_create("org.appcelerator.kroll.entry", DISPATCH_QUEUE_SERIAL);
-    dispatch_queue_set_specific(krollEntryQueue, krollEntryQueueKey, krollEntryQueueKey, NULL);
+    pthread_mutexattr_t entryLockAttrs;
+    pthread_mutexattr_init(&entryLockAttrs);
+    pthread_mutexattr_settype(&entryLockAttrs, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&KrollEntryLock, &entryLockAttrs);
+    pthread_mutexattr_destroy(&entryLockAttrs);
   }
 }
 

--- a/tests/Resources/ti.ui.label.test.js
+++ b/tests/Resources/ti.ui.label.test.js
@@ -292,6 +292,34 @@ describe('Titanium.UI.Label', function () {
 		win.open();
 	});
 
+	it.ios('does not deadlock when a window opens while setting HTML', function (finish) {
+		this.timeout(5000);
+
+		win = Ti.UI.createWindow();
+		const label = Ti.UI.createLabel({
+			text: 'This is a Label'
+		});
+		const button = Ti.UI.createButton();
+		const nextWindow = Ti.UI.createWindow();
+
+		button.addEventListener('click', function () {
+			nextWindow.open();
+			label.html = '<b>Dummy HTML</b><br/>The label was updated.';
+		});
+		nextWindow.addEventListener('open', function () {
+			nextWindow.close();
+		});
+		nextWindow.addEventListener('close', function () {
+			finish();
+		});
+		win.addEventListener('open', function listener() {
+			win.removeEventListener('open', listener);
+			setTimeout(() => button.fireEvent('click'), 100);
+		});
+		win.add([ label, button ]);
+		win.open();
+	});
+
 	describe.ios('.minimumFontSize', () => {
 		it('is a Number', () => {
 			const label = Ti.UI.createLabel({


### PR DESCRIPTION
## Summary
- Fix an iOS crash caused by queue-identity Kroll reentrancy detection during nested main run loops.
- Restore recursive mutex semantics so same-thread reentry and Objective-C exception propagation remain safe.
- Add deterministic integration coverage for opening a window while parsing label HTML.
- Fixes #14538.

## Changes
- Kroll locking: Replace the serial dispatch queue with an exception-safe recursive pthread mutex behind the existing helper.
- Tests: Exercise the button event, asynchronous window open, and label HTML nested-run-loop path.

## Test Plan
- [x] Reproduce the pre-fix `__DISPATCH_WAIT_FOR_QUEUE__` crash with the new regression test.
- [x] Run the focused Label regression test: 1 passed, 0 failed.
- [x] Run `Native exception surfaced`: 1 passed, 0 failed.
- [x] Run the complete Label suite: the regression passes; one unrelated `en-GB` localization assertion fails.
- [x] Run the broad iPhone integration suite without a process crash: 4,124 passed, 25 unrelated simulator/environment failures.
- [x] Run `npm run lint:objc`.
- [x] Run `npx oxlint tests/Resources/ti.ui.label.test.js`.
- [x] Run `npm run ios-sanity-check`.
