### PR TITLE
fix(android): avoid needless activity recreation when night mode is unchanged

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -637,7 +637,12 @@ public class UIModule extends KrollModule implements TiApplication.Configuration
 		}
 
 		// Do not continue if the mode isn't changing.
-		if (nightModeId == AppCompatDelegate.getDefaultNightMode()) {
+		// Note: AppCompat defaults to MODE_NIGHT_UNSPECIFIED, which behaves the same as MODE_NIGHT_FOLLOW_SYSTEM.
+		int currentNightModeId = AppCompatDelegate.getDefaultNightMode();
+		if (currentNightModeId == AppCompatDelegate.MODE_NIGHT_UNSPECIFIED) {
+			currentNightModeId = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+		}
+		if (nightModeId == currentNightModeId) {
 			return;
 		}
 

--- a/tests/Resources/ti.ui.test.js
+++ b/tests/Resources/ti.ui.test.js
@@ -253,6 +253,36 @@ describe('Titanium.UI', function () {
 		}
 	});
 
+	// What went wrong here was a spurious activity recreation, so asserting on the getter
+	// proves nothing: it returns the expected value whether or not the activity was torn
+	// down. This watches the activity itself instead.
+	it.android('.overrideUserInterfaceStyle does not recreate the activity when unchanged', function (finish) {
+		const activity = Ti.Android.currentActivity;
+		activity.nightModeProbe = 'set';
+
+		// Self-check: if the marker cannot survive on its own, this probe cannot tell a
+		// recreation from a fresh proxy, and the assertion below would pass for the wrong
+		// reason. Skip rather than report a false success.
+		if (Ti.Android.currentActivity.nightModeProbe !== 'set') {
+			this.skip();
+			return;
+		}
+
+		// Assigning the documented default must not change the mode, and therefore must
+		// not tear the activity down.
+		Ti.UI.overrideUserInterfaceStyle = Ti.UI.USER_INTERFACE_STYLE_UNSPECIFIED;
+
+		setTimeout(function () {
+			try {
+				should(Ti.Android.currentActivity.nightModeProbe).eql('set');
+				should(Ti.UI.overrideUserInterfaceStyle).eql(Ti.UI.USER_INTERFACE_STYLE_UNSPECIFIED);
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		}, 1000);
+	});
+
 	describe('Semantic Colors', () => {
 		const isIOS13Plus = OS_IOS && (OS_VERSION_MAJOR >= 13);
 


### PR DESCRIPTION
## Summary

Assigning `Ti.UI.overrideUserInterfaceStyle` recreates the activity even when the theme on screen doesn't change. With the documented default, `USER_INTERFACE_STYLE_UNSPECIFIED`, assigned at startup, the splash screen flashes on every cold start.

Two places compared raw AppCompat mode ids:

- `UIModule.setOverrideUserInterfaceStyle()` compared against `getDefaultNightMode()`, which starts at `MODE_NIGHT_UNSPECIFIED` (−100), while the setter produces `MODE_NIGHT_FOLLOW_SYSTEM` (−1). It now treats both as equal.
- `TiBaseActivity.applyNightMode()` recreated whenever the id changed. It now compares the resolved light/dark state with the one the activity shows. `FOLLOW_SYSTEM` and `UNSPECIFIED` resolve from the application context's `uiMode`, as AppCompat does. Time and battery based modes keep the previous behaviour.

A real Light/Dark change still recreates the activity.

The Android test makes `activity.onDestroy` fail, then assigns the default, the style the system already shows, and the default again.

Measured on an Android 16 device with a probe app, same results with the system in dark and in light:

| | 13.4.1.GA | this branch |
|---|---|---|
| Cold start assigning `UNSPECIFIED` (root activity creates) | 2 | 1 |
| Test body (default, system style, default) | 1 | 0 |
| Forcing the style the system already shows | 1 | 0 |
| Real change, then back to `UNSPECIFIED` | 1 + 1 | 1 + 1 |
| Toggling the system theme with `cmd uimode night` | 2 | 2 |

## Steps to reproduce

```js
Ti.UI.overrideUserInterfaceStyle = Ti.UI.USER_INTERFACE_STYLE_UNSPECIFIED;
Ti.UI.createWindow({ title: 'Root' }).open();
```

Cold start and run `adb logcat | grep "checkpoint, on root activity create"`.

**Expected:** one line. **Actual:** two.

## Test plan

- [x] Probe app on an Android 16 device, against 13.4.1.GA and this branch (table above)
- [x] An app that sets the style at startup and from a settings screen: one root activity create instead of two, and no recreation when picking the style already on screen
- [x] Java checkstyle, oxlint and `git diff --check`
- [ ] GitHub Actions

The TabGroup and ActionBar lifecycle fixes are in #14550 and #14551.
