### PR TITLE
fix(android): make TabGroup opening lifecycle-safe

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -26,6 +26,7 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 
 import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollPromise;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiActivity;
@@ -47,6 +48,7 @@ import org.appcelerator.titanium.util.TiUIHelper;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.CancellationException;
 
 import ti.modules.titanium.ui.android.AndroidModule;
 import ti.modules.titanium.ui.widget.tabgroup.TiUIAbstractTabGroup;
@@ -67,6 +69,7 @@ import ti.modules.titanium.ui.widget.tabgroup.TiUITabLayoutTabGroup;
 public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 {
 	private static final String TAG = "TabGroupProxy";
+	private static final int OPEN_ACTIVITY_RECREATION_RETRIES = 50;
 	private static final String PROPERTY_POST_TAB_GROUP_CREATED = "postTabGroupCreated";
 	private static final int MSG_FIRST_ID = TiWindowProxy.MSG_LAST_ID + 1;
 	protected static final int MSG_LAST_ID = MSG_FIRST_ID + 999;
@@ -84,6 +87,13 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	private boolean autoTabTitle = false;
 	private boolean isTabBarVisible = true;
 	private boolean isTabGroupEnabled = true;
+	private final Handler mainHandler = new Handler(Looper.getMainLooper());
+	private Runnable pendingOpenActivityRetry;
+	private Runnable pendingStartActivityRetry;
+	private long openGeneration;
+	private WeakReference<Activity> pendingOpenOwnerActivity = new WeakReference<>(null);
+	private WeakReference<TiWindowProxy> pendingOpenOwnerWindow = new WeakReference<>(null);
+	private int pendingOpenOwnerWindowId = TiActivityWindows.INVALID_WINDOW_ID;
 
 	public TabGroupProxy()
 	{
@@ -96,6 +106,20 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	public int getTabIndex(TabProxy tabProxy)
 	{
 		return tabs.indexOf(tabProxy);
+	}
+
+	@Override
+	@Kroll.method
+	public KrollPromise<Void> open(@Kroll.argument(optional = true) Object arg)
+	{
+		if (!opened && !opening) {
+			openGeneration++;
+			Activity owner = getActivity();
+			pendingOpenOwnerActivity = new WeakReference<>(owner);
+			pendingOpenOwnerWindow = new WeakReference<>(getOwnerWindow(owner));
+			pendingOpenOwnerWindowId = getActivityWindowId(owner);
+		}
+		return super.open(arg);
 	}
 
 	@Kroll.method
@@ -390,11 +414,164 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	@Override
 	protected void handleOpen(KrollDict options)
 	{
-		// Don't open if app is closing or closed
-		Activity topActivity = getActivity();
-		if (topActivity == null || topActivity.isFinishing() || topActivity.isDestroyed()) {
+		long generation = openGeneration;
+		Activity activity = pendingOpenOwnerActivity.get();
+		if (activity == null) {
+			activity = getActivity();
+		}
+		if (activity != null && activity.isFinishing()) {
+			handleOpenFailure(new IllegalStateException("TabGroup owner activity is finishing."));
 			return;
 		}
+
+		if (activity == null) {
+			handleOpenFailure(new IllegalStateException("No owner activity is available to open the TabGroup."));
+			return;
+		} else if (activity.isDestroyed() || activity.isChangingConfigurations()) {
+			if (!activity.isChangingConfigurations()) {
+				handleOpenFailure(new IllegalStateException("TabGroup owner activity was destroyed."));
+				return;
+			}
+			TiWindowProxy ownerWindow = getPendingOwnerWindow(activity);
+			int ownerWindowId = getPendingOwnerWindowId(activity);
+			Activity replacement = TiApplication.getAppCurrentActivity();
+			if (!isReplacementActivity(replacement, activity, ownerWindow, ownerWindowId)) {
+				waitForReplacementActivity(activity, ownerWindow, ownerWindowId, options, generation);
+				return;
+			}
+			activity = replacement;
+		}
+
+		openTabGroupWhenReady(activity, options, generation);
+	}
+
+	private boolean isActivityUsable(Activity activity)
+	{
+		return activity != null && !activity.isFinishing() && !activity.isDestroyed()
+			&& !activity.isChangingConfigurations();
+	}
+
+	private TiWindowProxy getOwnerWindow(Activity activity)
+	{
+		return activity instanceof TiBaseActivity ? ((TiBaseActivity) activity).getWindowProxy() : null;
+	}
+
+	private int getActivityWindowId(Activity activity)
+	{
+		Intent intent = activity != null ? activity.getIntent() : null;
+		return intent != null
+			? intent.getIntExtra(TiC.INTENT_PROPERTY_WINDOW_ID, TiActivityWindows.INVALID_WINDOW_ID)
+			: TiActivityWindows.INVALID_WINDOW_ID;
+	}
+
+	private TiWindowProxy getPendingOwnerWindow(Activity activity)
+	{
+		TiWindowProxy ownerWindow = pendingOpenOwnerWindow.get();
+		return ownerWindow != null ? ownerWindow : getOwnerWindow(activity);
+	}
+
+	private int getPendingOwnerWindowId(Activity activity)
+	{
+		return pendingOpenOwnerWindowId != TiActivityWindows.INVALID_WINDOW_ID
+			? pendingOpenOwnerWindowId
+			: getActivityWindowId(activity);
+	}
+
+	private void clearPendingOpenOwner()
+	{
+		pendingOpenOwnerActivity.clear();
+		pendingOpenOwnerWindow.clear();
+		pendingOpenOwnerWindowId = TiActivityWindows.INVALID_WINDOW_ID;
+	}
+
+	private boolean isCurrentOpen(long generation)
+	{
+		return opening && generation == openGeneration;
+	}
+
+	@Override
+	protected void handleOpenFailure(Throwable error)
+	{
+		clearPendingOpenCallbacks();
+		clearPendingOpenOwner();
+		TiActivityWindows.removeWindow(this);
+		super.handleOpenFailure(error);
+	}
+
+	private boolean isReplacementActivity(
+		Activity candidate, Activity previous, TiWindowProxy ownerWindow, int ownerWindowId)
+	{
+		if (!isActivityUsable(candidate) || candidate == previous) {
+			return false;
+		}
+		if (ownerWindowId != TiActivityWindows.INVALID_WINDOW_ID) {
+			return getActivityWindowId(candidate) == ownerWindowId;
+		}
+		if (ownerWindow != null) {
+			return candidate instanceof TiBaseActivity
+				&& ((TiBaseActivity) candidate).getWindowProxy() == ownerWindow;
+		}
+		return previous instanceof TiRootActivity && candidate.getClass().equals(previous.getClass());
+	}
+
+	private void waitForReplacementActivity(
+		Activity previous, TiWindowProxy ownerWindow, int ownerWindowId, KrollDict options, long generation)
+	{
+		clearPendingOpenActivityRetry();
+		pendingOpenActivityRetry =
+			() -> waitForReplacementActivity(previous, ownerWindow, ownerWindowId, options, generation, 0);
+		mainHandler.post(pendingOpenActivityRetry);
+	}
+
+	private void waitForReplacementActivity(
+		Activity previous, TiWindowProxy ownerWindow, int ownerWindowId, KrollDict options, long generation,
+		int attempt)
+	{
+		pendingOpenActivityRetry = null;
+		if (!isCurrentOpen(generation)) {
+			return;
+		}
+		Activity current = TiApplication.getAppCurrentActivity();
+		if (isReplacementActivity(current, previous, ownerWindow, ownerWindowId)) {
+			openTabGroupWhenReady(current, options, generation);
+			return;
+		}
+		if (attempt >= OPEN_ACTIVITY_RECREATION_RETRIES) {
+			handleOpenFailure(new IllegalStateException("Timed out waiting for the recreated owner activity."));
+			return;
+		}
+		pendingOpenActivityRetry = () ->
+			waitForReplacementActivity(previous, ownerWindow, ownerWindowId, options, generation, attempt + 1);
+		mainHandler.postDelayed(pendingOpenActivityRetry, 100);
+	}
+
+	private void clearPendingOpenActivityRetry()
+	{
+		if (pendingOpenActivityRetry != null) {
+			mainHandler.removeCallbacks(pendingOpenActivityRetry);
+			pendingOpenActivityRetry = null;
+		}
+	}
+
+	private void clearPendingOpenCallbacks()
+	{
+		clearPendingOpenActivityRetry();
+		if (pendingStartActivityRetry != null) {
+			mainHandler.removeCallbacks(pendingStartActivityRetry);
+			pendingStartActivityRetry = null;
+		}
+	}
+
+	private void openTabGroupWhenReady(Activity activity, KrollDict options, long generation)
+	{
+		if (!isCurrentOpen(generation)) {
+			return;
+		}
+		if (!isActivityUsable(activity)) {
+			recoverFromActivityRecreationOrFail(activity, options, generation);
+			return;
+		}
+		final Activity topActivity = activity;
 
 		/**
 		 * Only applicable on Android 12 or Android 13.
@@ -406,24 +583,52 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 			Window window = topActivity.getWindow();
 			View decorView = window != null ? window.getDecorView() : null;
 			if (decorView == null) {
+				handleOpenFailure(new IllegalStateException("TabGroup owner activity has no decor view."));
 				return;
 			}
 
 			if (decorView.getDisplay() == null) {
 				TiSafeDisplay.getDisplaySafely(decorView, isDisplayAvailable -> {
-					// Display may not be available in very very rare cases,
-					// but we open it since it's now in try-catch.
-					openTabGroup(topActivity, options);
+					if (!isCurrentOpen(generation)) {
+						return;
+					}
+					if (isDisplayAvailable && isActivityUsable(topActivity)) {
+						openTabGroup(topActivity, options, generation);
+					} else {
+						recoverFromActivityRecreationOrFail(topActivity, options, generation);
+					}
 				});
 				return;
 			}
 		}
 
-		openTabGroup(topActivity, options);
+		openTabGroup(topActivity, options, generation);
 	}
 
-	private void openTabGroup(Activity topActivity, KrollDict options)
+	private void recoverFromActivityRecreationOrFail(Activity previous, KrollDict options, long generation)
 	{
+		if (!isCurrentOpen(generation)) {
+			return;
+		}
+		if (previous != null && !previous.isFinishing() && previous.isChangingConfigurations()) {
+			TiWindowProxy ownerWindow = getPendingOwnerWindow(previous);
+			int ownerWindowId = getPendingOwnerWindowId(previous);
+			Activity replacement = TiApplication.getAppCurrentActivity();
+			if (isReplacementActivity(replacement, previous, ownerWindow, ownerWindowId)) {
+				openTabGroupWhenReady(replacement, options, generation);
+			} else {
+				waitForReplacementActivity(previous, ownerWindow, ownerWindowId, options, generation);
+			}
+			return;
+		}
+		handleOpenFailure(new IllegalStateException("TabGroup owner activity is no longer available."));
+	}
+
+	private void openTabGroup(Activity topActivity, KrollDict options, long generation)
+	{
+		if (!isCurrentOpen(generation)) {
+			return;
+		}
 		// set theme for XML layout
 		if (hasProperty(TiC.PROPERTY_STYLE)
 			&& ((Integer) getProperty(TiC.PROPERTY_STYLE)) == AndroidModule.TABS_STYLE_BOTTOM_NAVIGATION
@@ -468,13 +673,24 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 			// Last attempt to open the TabGroup (without any animation this time) as reported here:
 			// https://issuetracker.google.com/issues/293645024
 			intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-			new Handler(Looper.getMainLooper()).postDelayed(() -> {
+			pendingStartActivityRetry = () -> {
+				pendingStartActivityRetry = null;
+				if (!isCurrentOpen(generation)) {
+					return;
+				}
+				if (!isActivityUsable(topActivity)) {
+					TiActivityWindows.removeWindow(this);
+					recoverFromActivityRecreationOrFail(topActivity, options, generation);
+					return;
+				}
 				try {
 					topActivity.startActivity(intent);
 				} catch (Exception ex) {
-					throw new RuntimeException("TabGroup failed to open: " + ex);
+					TiActivityWindows.removeWindow(this);
+					handleOpenFailure(new RuntimeException("TabGroup failed to open.", ex));
 				}
-			}, 500); // Just a hypothetical delay.
+			};
+			mainHandler.postDelayed(pendingStartActivityRetry, 500); // Just a hypothetical delay.
 		}
 	}
 
@@ -586,6 +802,8 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	@Override
 	protected void handlePostOpen()
 	{
+		clearPendingOpenCallbacks();
+		clearPendingOpenOwner();
 		super.handlePostOpen();
 
 		if (view == null) {
@@ -624,7 +842,16 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	protected void handleClose(@NonNull KrollDict options)
 	{
 		Log.d(TAG, "handleClose: " + options, Log.DEBUG_MODE);
-
+		clearPendingOpenCallbacks();
+		boolean cancelledOpen = opening && !opened;
+		if (cancelledOpen) {
+			handleOpenFailure(new CancellationException("TabGroup open was cancelled by close()."));
+			if (closePromise != null) {
+				closePromise.resolve(null);
+				closePromise = null;
+			}
+		}
+		clearPendingOpenOwner();
 		// Remove this TabGroup proxy from the active/open collection.
 		// Note: If the activity's onCreate() can't find this proxy, then it'll automatically destroy itself.
 		//       This is needed in case the proxy's close() method was called before the activity was created.
@@ -634,6 +861,9 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		modelListener = null;
 		releaseViews();
 		view = null;
+		if (cancelledOpen) {
+			return;
+		}
 
 		// Destroy this proxy's activity.
 		AppCompatActivity activity = (tabGroupActivity != null) ? tabGroupActivity.get() : null;

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -140,6 +140,22 @@ public abstract class TiWindowProxy extends TiViewProxy
 		return openPromise;
 	}
 
+	/**
+	 * Settles an open operation that cannot reach {@link #handlePostOpen()}.
+	 * @param error reason the window could not be opened
+	 */
+	protected void handleOpenFailure(Throwable error)
+	{
+		opening = false;
+		if (waitingForOpen != null && waitingForOpen.get() == this) {
+			waitingForOpen = null;
+		}
+		if (openPromise != null) {
+			openPromise.reject(error);
+			openPromise = null;
+		}
+	}
+
 	@Kroll.getProperty(name = "closed")
 	public boolean isClosed()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiSafeDisplay.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiSafeDisplay.java
@@ -1,10 +1,16 @@
 package org.appcelerator.titanium.util;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.view.Display;
 import android.view.View;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class TiSafeDisplay
 {
+	private static final long DISPLAY_WAIT_TIMEOUT_MS = 5000;
+
 	public interface DisplayCallback {
 		void onDisplayAvailable(Boolean isDisplayAvailable);
 	}
@@ -21,24 +27,44 @@ public class TiSafeDisplay
 			}
 		}
 
-		view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+		Handler handler = new Handler(Looper.getMainLooper());
+		AtomicBoolean completed = new AtomicBoolean();
+		class DisplayListener implements View.OnAttachStateChangeListener
+		{
+			private final Runnable timeout = () -> complete(false);
+
+			private void complete(boolean available)
+			{
+				if (!completed.compareAndSet(false, true)) {
+					return;
+				}
+				view.removeOnAttachStateChangeListener(this);
+				handler.removeCallbacks(timeout);
+				callback.onDisplayAvailable(available);
+			}
+
 			@Override
 			public void onViewAttachedToWindow(View v)
 			{
-				v.removeOnAttachStateChangeListener(this);
-
 				/**
 				 * It's rare that a display is not available even at this stage.
 				 * Since `getDisplay()` returns null, send a boolean to make proper decisions.
 				 */
-				callback.onDisplayAvailable(v.getDisplay() != null);
+				complete(v.getDisplay() != null);
 			}
 
 			@Override
 			public void onViewDetachedFromWindow(View v)
 			{
-				v.removeOnAttachStateChangeListener(this);
+				complete(false);
 			}
-		});
+		}
+
+		DisplayListener listener = new DisplayListener();
+		view.addOnAttachStateChangeListener(listener);
+		handler.postDelayed(listener.timeout, DISPLAY_WAIT_TIMEOUT_MS);
+		if (view.getDisplay() != null) {
+			listener.complete(true);
+		}
 	}
 }

--- a/tests/Resources/ti.ui.tabgroup.test.js
+++ b/tests/Resources/ti.ui.tabgroup.test.js
@@ -18,12 +18,21 @@ describe('Titanium.UI.TabGroup', function () {
 	this.timeout(5000);
 
 	let tabGroup;
+	let ownerWindow;
 	afterEach(done => { // fires after every test in sub-suites too...
-		if (tabGroup && !tabGroup.closed) {
-			tabGroup.close().then(() => done()).catch(_e => done());
-		} else {
+		const closeOwner = () => {
 			tabGroup = null;
-			done();
+			if (ownerWindow && !ownerWindow.closed) {
+				ownerWindow.close().then(done).catch(done);
+			} else {
+				done();
+			}
+			ownerWindow = null;
+		};
+		if (tabGroup && !tabGroup.closed) {
+			tabGroup.close().then(closeOwner).catch(closeOwner);
+		} else {
+			closeOwner();
 		}
 	});
 
@@ -482,6 +491,67 @@ describe('Titanium.UI.TabGroup', function () {
 					// eslint-disable-next-line promise/no-nesting
 					return second.then(() => finish(new Error('Expected second #open() to be rejected'))).catch(() => finish());
 				}).catch(e => finish(e));
+			});
+
+			it.android('rejects when its owner activity is finishing', function (finish) {
+				this.timeout(10000);
+				let settled = false;
+				const complete = err => {
+					if (!settled) {
+						settled = true;
+						finish(err);
+					}
+				};
+				ownerWindow = Ti.UI.createWindow();
+				ownerWindow.open().then(() => {
+					const tab = Ti.UI.createTab({
+						title: 'Tab',
+						window: Ti.UI.createWindow()
+					});
+					tabGroup = Ti.UI.createTabGroup();
+					tabGroup.addTab(tab);
+					ownerWindow.activity.finish();
+
+					const timeout = setTimeout(() => complete(new Error('Expected #open() to settle')), 7000);
+					tabGroup.open().then(() => {
+						clearTimeout(timeout);
+						complete(new Error('Expected #open() to reject for a finishing owner activity'));
+					}).catch(err => {
+						clearTimeout(timeout);
+						try {
+							should(err.message).containEql('finishing');
+							should(tabGroup.closed).be.true();
+							complete();
+						} catch (err) {
+							complete(err);
+						}
+					});
+				}).catch(complete);
+			});
+
+			it.android('settles both promises and can reopen when close immediately follows open', function (finish) {
+				this.timeout(10000);
+				ownerWindow = Ti.UI.createWindow();
+				ownerWindow.open().then(() => {
+					const tab = Ti.UI.createTab({ title: 'Tab', window: Ti.UI.createWindow() });
+					tabGroup = Ti.UI.createTabGroup();
+					tabGroup.addTab(tab);
+					const openPromise = tabGroup.open();
+					const closePromise = tabGroup.close();
+					Promise.allSettled([ openPromise, closePromise ]).then(results => {
+						should(results[0].status).eql('rejected');
+						should(results[1].status).eql('fulfilled');
+						should(tabGroup.closed).be.true();
+						return tabGroup.open();
+					}).then(() => {
+						try {
+							should(tabGroup.closed).be.false();
+							finish();
+						} catch (err) {
+							finish(err);
+						}
+					}).catch(finish);
+				}).catch(finish);
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

Opening a `TabGroup` can get stuck on the splash screen when its owner Activity is recreated while `open()` is still pending. `KrollPromise.create()` dispatches the work asynchronously, so resolving the owner inside `handleOpen()` can return a replacement or an unrelated Activity, and the promise never settles.

This captures the owner when `open()` is invoked and then waits a bounded time for a usable replacement belonging to the same Titanium window. The existing root-Activity fallback stays. If the original owner is really closing, the open promise rejects instead of returning silently. Delayed work is generation-guarded and cancelled after success, failure or `close()`, and `TiSafeDisplay` now completes once and has a timeout, so an attach callback cannot leave the promise pending forever. Calling `close()` during a pending open settles both promises and lets the same proxy be opened again.

No public API or Window `close` event semantics change.

## Steps to reproduce

Use a `TabGroup` as the root UI and trigger an Activity recreation while its asynchronous `open()` is pending. Assigning a different interface style during startup is one way to reproduce it:

```js
Ti.UI.overrideUserInterfaceStyle = Ti.UI.USER_INTERFACE_STYLE_LIGHT;

const tabGroup = Ti.UI.createTabGroup();
const win = Ti.UI.createWindow({ title: 'Tab One' });
tabGroup.addTab(Ti.UI.createTab({ title: 'One', window: win }));
tabGroup.open();
```

**Expected:** the `TabGroup` opens and the promise settles.

**Actual:** the app can remain on the splash screen with the open promise pending.

## Test plan

- [x] Root `TabGroup` opens after its owner Activity is recreated
- [x] Opening from a finishing owner rejects instead of using an unrelated Activity
- [x] `open()` followed immediately by `close()` settles both promises, and the same proxy reopens
- [x] Verified on Android 10 (API 29), Android 13 (API 33) and a physical Android 16 (API 36)
