### PR TITLE
fix(android): restore ActionBar up navigation after recreation

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -957,6 +957,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 				finish();
 			}
 		}
+		activityProxy.restoreActionBar();
 	}
 
 	/**

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
@@ -34,15 +34,25 @@ public class ActionBarProxy extends KrollProxy
 
 	// Weak references so a proxy kept alive by JS cannot leak a destroyed activity
 	// or its view hierarchy (the toolbar's context is the activity).
-	private final WeakReference<AppCompatActivity> activityRef;
-	private final WeakReference<Toolbar> toolbarRef;
+	private WeakReference<AppCompatActivity> activityRef;
+	private WeakReference<Toolbar> toolbarRef;
 	private boolean showTitleEnabled = true;
+	private boolean restoreDisplayHomeAsUp;
 
 	public ActionBarProxy(AppCompatActivity activity)
 	{
 		super();
 		this.activityRef = new WeakReference<>(activity);
 		this.toolbarRef = new WeakReference<>(findActionBarToolbar(activity));
+	}
+
+	public void rebind(AppCompatActivity activity)
+	{
+		this.activityRef = new WeakReference<>(activity);
+		this.toolbarRef = new WeakReference<>(findActionBarToolbar(activity));
+		if (restoreDisplayHomeAsUp) {
+			setDisplayHomeAsUp(true);
+		}
 	}
 
 	private Toolbar getToolbar()
@@ -79,6 +89,7 @@ public class ActionBarProxy extends KrollProxy
 	@Kroll.setProperty
 	public void setDisplayHomeAsUp(boolean showHomeAsUp)
 	{
+		restoreDisplayHomeAsUp = showHomeAsUp;
 		Toolbar toolbar = getToolbar();
 		if (toolbar != null) {
 			toolbar.setNavigationIcon(getHomeAsUpIcon(showHomeAsUp));
@@ -103,6 +114,7 @@ public class ActionBarProxy extends KrollProxy
 	@Kroll.setProperty
 	public void setHomeAsUpIndicator(Object icon)
 	{
+		restoreDisplayHomeAsUp = false;
 		Toolbar toolbar = getToolbar();
 		if (toolbar == null) {
 			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
@@ -120,6 +132,7 @@ public class ActionBarProxy extends KrollProxy
 	@Kroll.setProperty
 	public void setHomeButtonEnabled(boolean homeButtonEnabled)
 	{
+		restoreDisplayHomeAsUp = false;
 		Toolbar toolbar = getToolbar();
 		if (toolbar != null) {
 			toolbar.setNavigationIcon(homeButtonEnabled ? getHomeAsUpIcon(true) : null);
@@ -152,6 +165,7 @@ public class ActionBarProxy extends KrollProxy
 	@Kroll.method
 	public void setDisplayShowHomeEnabled(boolean show)
 	{
+		restoreDisplayHomeAsUp = false;
 		Toolbar toolbar = getToolbar();
 		if (toolbar != null) {
 			if (show) {
@@ -312,6 +326,7 @@ public class ActionBarProxy extends KrollProxy
 	@Kroll.setProperty
 	public void setIcon(Object image)
 	{
+		restoreDisplayHomeAsUp = false;
 		Toolbar toolbar = getToolbar();
 		if (toolbar == null) {
 			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
@@ -331,6 +346,7 @@ public class ActionBarProxy extends KrollProxy
 	{
 		Toolbar toolbar = getToolbar();
 		if (TiC.PROPERTY_ON_HOME_ICON_ITEM_SELECTED.equals(name)) {
+			restoreDisplayHomeAsUp = true;
 			if (toolbar != null) {
 				toolbar.setNavigationIcon(getHomeAsUpIcon(true));
 			}

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ActivityProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ActivityProxy.java
@@ -56,6 +56,7 @@ public class ActivityProxy extends KrollProxy implements TiActivityResultHandler
 	protected IntentProxy intentProxy;
 	protected DecorViewProxy savedDecorViewProxy;
 	protected ActionBarProxy actionBarProxy;
+	private boolean isActionBarProxyBorrowed;
 
 	private KrollFunction resultCallback;
 
@@ -289,9 +290,31 @@ public class ActivityProxy extends KrollProxy implements TiActivityResultHandler
 	{
 		AppCompatActivity activity = (AppCompatActivity) getWrappedActivity();
 		if (actionBarProxy == null && activity != null) {
-			actionBarProxy = new ActionBarProxy(activity);
+			TiWindowProxy window = getWindow();
+			if (window == null) {
+				actionBarProxy = new ActionBarProxy(activity);
+				isActionBarProxyBorrowed = false;
+			} else {
+				actionBarProxy = window.getActionBarProxy();
+				if (actionBarProxy == null) {
+					actionBarProxy = new ActionBarProxy(activity);
+					window.setActionBarProxy(actionBarProxy);
+				}
+				isActionBarProxyBorrowed = true;
+			}
 		}
 		return actionBarProxy;
+	}
+
+	public void restoreActionBar()
+	{
+		TiWindowProxy window = getWindow();
+		if (window == null || window.getActionBarProxy() == null) {
+			return;
+		}
+		actionBarProxy = window.getActionBarProxy();
+		isActionBarProxyBorrowed = true;
+		actionBarProxy.rebind((AppCompatActivity) getWrappedActivity());
 	}
 
 	@Kroll.method
@@ -370,8 +393,11 @@ public class ActivityProxy extends KrollProxy implements TiActivityResultHandler
 			intentProxy = null;
 		}
 		if (actionBarProxy != null) {
-			actionBarProxy.release();
+			if (!isActionBarProxyBorrowed) {
+				actionBarProxy.release();
+			}
 			actionBarProxy = null;
+			isActionBarProxyBorrowed = false;
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -68,6 +68,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 
 	protected boolean opened, opening;
 	protected boolean isFocused;
+	private ActionBarProxy actionBarProxy;
 	protected int[] orientationModes = null;
 	protected TiViewProxy tabGroup;
 	protected TiViewProxy tab;
@@ -195,6 +196,10 @@ public abstract class TiWindowProxy extends TiViewProxy
 		KrollDict data = null;
 		if (activityIsFinishing) {
 			releaseViews();
+			if (actionBarProxy != null) {
+				actionBarProxy.release();
+				actionBarProxy = null;
+			}
 		} else {
 			// If the activity is forced to destroy by Android OS due to lack of memory or
 			// enabling "Don't keep activities" (TIMOB-12939), we will not release the
@@ -219,6 +224,16 @@ public abstract class TiWindowProxy extends TiViewProxy
 	public void addProxyWaitingForActivity(KrollProxy waitingProxy)
 	{
 		proxiesWaitingForActivity.add(new WeakReference<>(waitingProxy));
+	}
+
+	public ActionBarProxy getActionBarProxy()
+	{
+		return actionBarProxy;
+	}
+
+	public void setActionBarProxy(ActionBarProxy proxy)
+	{
+		actionBarProxy = proxy;
 	}
 
 	protected void releaseViewsForActivityForcedToDestroy()


### PR DESCRIPTION
## Summary

An Activity recreation replaces the native ActionBar and its Activity proxy. Titanium keeps the Window proxy alive through that temporary destruction, but the ActionBar proxy was owned only by the old Activity proxy, so the replacement Activity consulted a new proxy with no up-navigation callback.

This moves ownership to the surviving Window. Each replacement Activity borrows the proxy and rebinds it to the new native ActionBar, and a real Window close releases it, so the up affordance and `onHomeIconItemSelected` keep referring to the same proxy. Other ActionBar properties and app-provided `supportToolbar` instances are outside this fix. There are no public API changes.

## Steps to reproduce

```js
const win = Ti.UI.createWindow({ title: 'Child' });

win.addEventListener('open', function once() {
	win.removeEventListener('open', once);
	win.activity.actionBar.displayHomeAsUp = true;
	win.activity.actionBar.onHomeIconItemSelected = () => {
		Ti.API.info('HOME ICON SELECTED');
	};
});

win.open();
```

With that window open, change the interface style:

```js
Ti.UI.overrideUserInterfaceStyle = Ti.UI.USER_INTERFACE_STYLE_DARK;
```

**Expected:** the up arrow remains visible and still invokes the callback.

**Actual:** the replacement Activity uses a different ActionBar proxy, so the arrow and native callback path are lost.

## Test plan

- [x] After a native `Activity.recreate()`, the replacement still shows the up affordance and still invokes `onHomeIconItemSelected`
- [x] The callback fires exactly once before and once after recreation, with no duplicate
- [x] A real Window close still releases the Window-owned ActionBar proxy
- [x] Verified on Android 10 (API 29), Android 13 (API 33) and a physical Android 16 (API 36)

The recreation check uses an isolated child Activity because changing the shared TiMocha root Activity resets the test runner. A Hyperloop harness invokes the native recreation without adding a test-only API to Titanium.
