### PR TITLE
feat(ios): add CFBundleVersion comment to tiapp.xml

### DIFF
--- a/templates/app/angular-default/template/tiapp.xml
+++ b/templates/app/angular-default/template/tiapp.xml
@@ -38,7 +38,8 @@
 				<key>UIStatusBarStyle</key>
 				<string>UIStatusBarStyleLightContent</string>
 				<!-- use this key for incremental TestFlight builds with the same version number
-				<key>CFBundleVersion</key><string>1</string>
+				<key>CFBundleVersion</key>
+				<string>1</string>
 				-->
 			</dict>
 		</plist>

--- a/templates/app/angular-default/template/tiapp.xml
+++ b/templates/app/angular-default/template/tiapp.xml
@@ -37,6 +37,7 @@
 				<false/>
 				<key>UIStatusBarStyle</key>
 				<string>UIStatusBarStyleLightContent</string>
+				<!-- <key>CFBundleVersion</key><string>1</string> -->
 			</dict>
 		</plist>
 	</ios>

--- a/templates/app/angular-default/template/tiapp.xml
+++ b/templates/app/angular-default/template/tiapp.xml
@@ -37,7 +37,9 @@
 				<false/>
 				<key>UIStatusBarStyle</key>
 				<string>UIStatusBarStyleLightContent</string>
-				<!-- <key>CFBundleVersion</key><string>1</string> -->
+				<!-- use this key for incremental TestFlight builds with the same version number
+				<key>CFBundleVersion</key><string>1</string>
+				-->
 			</dict>
 		</plist>
 	</ios>

--- a/templates/app/default/template/tiapp.xml
+++ b/templates/app/default/template/tiapp.xml
@@ -37,7 +37,9 @@
 				<false/>
 				<key>UIStatusBarStyle</key>
 				<string>UIStatusBarStyleDefault</string>
-				<!-- <key>CFBundleVersion</key><string>1</string> -->
+				<!-- use this key for incremental TestFlight builds with the same version number
+				<key>CFBundleVersion</key><string>1</string>
+				-->
 			</dict>
 		</plist>
 	</ios>

--- a/templates/app/default/template/tiapp.xml
+++ b/templates/app/default/template/tiapp.xml
@@ -37,6 +37,7 @@
 				<false/>
 				<key>UIStatusBarStyle</key>
 				<string>UIStatusBarStyleDefault</string>
+				<!-- <key>CFBundleVersion</key><string>1</string> -->
 			</dict>
 		</plist>
 	</ios>

--- a/templates/app/default/template/tiapp.xml
+++ b/templates/app/default/template/tiapp.xml
@@ -38,7 +38,8 @@
 				<key>UIStatusBarStyle</key>
 				<string>UIStatusBarStyleDefault</string>
 				<!-- use this key for incremental TestFlight builds with the same version number
-				<key>CFBundleVersion</key><string>1</string>
+				<key>CFBundleVersion</key>
+				<string>1</string>
 				-->
 			</dict>
 		</plist>

--- a/templates/app/webpack-default/template/tiapp.xml
+++ b/templates/app/webpack-default/template/tiapp.xml
@@ -36,7 +36,9 @@
 				<false/>
 				<key>UIStatusBarStyle</key>
 				<string>UIStatusBarStyleLightContent</string>
-				<!-- <key>CFBundleVersion</key><string>1</string> -->
+				<!-- use this key for incremental TestFlight builds with the same version number
+				<key>CFBundleVersion</key><string>1</string>
+				-->
 			</dict>
 		</plist>
 	</ios>

--- a/templates/app/webpack-default/template/tiapp.xml
+++ b/templates/app/webpack-default/template/tiapp.xml
@@ -37,7 +37,8 @@
 				<key>UIStatusBarStyle</key>
 				<string>UIStatusBarStyleLightContent</string>
 				<!-- use this key for incremental TestFlight builds with the same version number
-				<key>CFBundleVersion</key><string>1</string>
+				<key>CFBundleVersion</key>
+				<string>1</string>
 				-->
 			</dict>
 		</plist>

--- a/templates/app/webpack-default/template/tiapp.xml
+++ b/templates/app/webpack-default/template/tiapp.xml
@@ -36,6 +36,7 @@
 				<false/>
 				<key>UIStatusBarStyle</key>
 				<string>UIStatusBarStyleLightContent</string>
+				<!-- <key>CFBundleVersion</key><string>1</string> -->
 			</dict>
 		</plist>
 	</ios>


### PR DESCRIPTION
For the Android version we already the `android:versionCode="1"` in the tiapp.xml. iOS will currently always use the normal `<version>` though you can't increase a TestFlight app with the same version number. For that you'll need to use `CFBundleVersion`. I've kept it as a comment so it won't if you don't want to use it or keep the `version` as a `CFBundleVersion` you keep it as it is. 
But for the people who want to use it they can comment it out and not need to search for the plist key.