### PR TITLE
fix(ios): update TabGroup background when changing the window background

### DIFF
--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -29,6 +29,9 @@
   BOOL iconOriginal;
   BOOL activeIconOriginal;
   UITraitCollection *lastTabBarTraitCollection;
+  // The visible window's view, observed so the tab group keeps matching its
+  // background colour instead of copying it once.
+  UIView *observedWindowView;
 
   id<TiOrientationController> parentOrientationController;
 

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -25,7 +25,12 @@
 @interface TiUITabProxy ()
 - (void)openOnUIThread:(NSArray *)args;
 - (BOOL)lazyLoadingEnabled;
+- (void)trackBackgroundColorOfWindow:(TiWindowProxy *)windowProxy;
+- (void)stopTrackingWindowBackgroundColor;
+- (void)applyWindowBackgroundColor;
 @end
+
+static void *TiUITabWindowBackgroundContext = &TiUITabWindowBackgroundContext;
 
 @implementation TiUITabProxy
 
@@ -41,6 +46,7 @@
   if (rootWindow != nil) {
     [self cleanNavStack:YES];
   }
+  [self stopTrackingWindowBackgroundColor];
   RELEASE_TO_NIL(controllerStack);
   RELEASE_TO_NIL(rootWindow);
   RELEASE_TO_NIL(controller);
@@ -408,6 +414,71 @@
   // NO OP NOW
 }
 
+#pragma mark - Tab group background colour
+
+// The tab group's controller view is what shows through wherever the window's own
+// view does not reach - most visibly the strip behind the iOS 26 floating tab bar,
+// whose Liquid Glass samples it. Track the window rather than copying its colour
+// once, so a backgroundColor assigned after the window is shown still lands.
+- (void)applyWindowBackgroundColor
+{
+  if (tabGroup == nil || observedWindowView == nil) {
+    return;
+  }
+  TiUITabGroup *tabGroupView = (TiUITabGroup *)[tabGroup view];
+  [[tabGroupView tabController] view].backgroundColor = observedWindowView.backgroundColor;
+}
+
+- (void)trackBackgroundColorOfWindow:(TiWindowProxy *)windowProxy
+{
+  UIView *windowView = (windowProxy != nil) ? [windowProxy view] : nil;
+
+  if (windowView != observedWindowView) {
+    [self stopTrackingWindowBackgroundColor];
+
+    if (windowView != nil) {
+      observedWindowView = [windowView retain];
+      // Observe the layer, not the view: TiUIView assigns through
+      // `super.backgroundColor`, which dispatches past the KVO subclass, so
+      // observing the view itself never fires. The layer still sees the write.
+      [observedWindowView.layer addObserver:self
+                                 forKeyPath:@"backgroundColor"
+                                    options:NSKeyValueObservingOptionNew
+                                    context:TiUITabWindowBackgroundContext];
+    }
+  }
+
+  // Match whatever the window carries right now, not only its next change.
+  [self applyWindowBackgroundColor];
+}
+
+- (void)stopTrackingWindowBackgroundColor
+{
+  if (observedWindowView != nil) {
+    [observedWindowView.layer removeObserver:self
+                                  forKeyPath:@"backgroundColor"
+                                     context:TiUITabWindowBackgroundContext];
+    RELEASE_TO_NIL(observedWindowView);
+  }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+  if (context == TiUITabWindowBackgroundContext) {
+    if ([NSThread isMainThread]) {
+      [self applyWindowBackgroundColor];
+    } else {
+      TiThreadPerformOnMainThread(
+          ^{
+            [self applyWindowBackgroundColor];
+          },
+          NO);
+    }
+    return;
+  }
+  [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+}
+
 #pragma mark - UINavigationControllerDelegate
 
 #ifdef USE_TI_UIIOSTRANSITIONANIMATION
@@ -436,7 +507,7 @@
     TiViewController *toViewController = (TiViewController *)viewController;
     if ([[toViewController proxy] isKindOfClass:[TiWindowProxy class]]) {
       TiWindowProxy *windowProxy = (TiWindowProxy *)[toViewController proxy];
-      [((TiUITabGroup *)(tabGroup.view)) tabController].view.backgroundColor = windowProxy.view.backgroundColor;
+      [self trackBackgroundColorOfWindow:windowProxy];
     }
   }
   [self handleWillShowViewController:viewController animated:animated];

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -422,7 +422,10 @@ static void *TiUITabWindowBackgroundContext = &TiUITabWindowBackgroundContext;
 // once, so a backgroundColor assigned after the window is shown still lands.
 - (void)applyWindowBackgroundColor
 {
-  if (tabGroup == nil || observedWindowView == nil) {
+  // The controller view is shared by every tab, so only the focused tab may
+  // paint it; a hidden tab's window changing colour must not repaint the strip
+  // under the visible one. handleDidFocus re-applies once this tab takes over.
+  if (!hasFocus || tabGroup == nil || observedWindowView == nil) {
     return;
   }
   TiUITabGroup *tabGroupView = (TiUITabGroup *)[tabGroup view];
@@ -641,6 +644,7 @@ static void *TiUITabWindowBackgroundContext = &TiUITabWindowBackgroundContext;
       }
     }
   }
+  [self applyWindowBackgroundColor];
 
   if ([self _hasListeners:@"focus"]) {
     [self fireEvent:@"focus" withObject:event withSource:self propagate:NO reportSuccess:NO errorCode:0 message:nil];


### PR DESCRIPTION
While debugging a different issue Claude found this one in the TabGroup:

When you change your window color in a tabgroup setup it won't update the color behind the bottom navigation automatically. You have to switch tabs for it to update.

13.4.0.GA:

https://github.com/user-attachments/assets/0671f4c7-b570-4a23-aaaf-007f361e5c21

with this PR:


https://github.com/user-attachments/assets/3bc58a02-62bc-4297-8b5e-347d4f2f1e2e



```js
var COLORS = ['#00287e', '#e0651a'];
var index = 0;
var windows = [];

function toggle() {
	index = (index + 1) % COLORS.length;
	windows.forEach(function (win) {
	  win.backgroundColor = COLORS[index];
	  win.barColor = COLORS[index];  // note: has to be set, otherwise it stays at the original barColor (TiUIWindowProxy.m:373)
	});
	Ti.API.info('backgroundColor is now ' + COLORS[index]);
}

function createTab(title) {
	var win = Ti.UI.createWindow({ backgroundColor: COLORS[0] });
	win.add(Ti.UI.createLabel({
		color: '#fff',
		textAlign: 'center',
		text: 'Tap anywhere to change the window backgroundColor.\n\n'
			+ 'PASS: the strip behind and below the tab bar\nchanges colour with the window.\n\n'
			+ 'FAIL: the window changes but that strip stays\n' + COLORS[0] + '.'
	}));
	win.addEventListener('click', toggle);
	windows.push(win);
	return Ti.UI.createTab({ title: title, window: win });
}

Ti.UI.createTabGroup({
	tabs: [createTab('One'), createTab('Two')]
}).open();
```

* run app
* click on the background
* check  the background color