### PR TITLE
feat: async command `validate()` and `run()`

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -17,7 +17,7 @@ import { detect as androidDetect } from '../lib/detect.js';
 import { AndroidManifest } from '../lib/android-manifest.js';
 import appc from 'node-appc';
 import async from 'async';
-import Builder from 'node-titanium-sdk/lib/builder.js';
+import { Builder } from '../../../cli/lib/builder.js';
 import { GradleWrapper } from '../lib/gradle-wrapper.js';
 import { ProcessJsTask } from '../../../cli/lib/tasks/process-js-task.js';
 import { ProcessDrawablesTask } from '../lib/process-drawables-task.js';
@@ -860,8 +860,8 @@ class AndroidBuilder extends Builder {
 		}.bind(this);
 	}
 
-	validate(logger, config, cli) {
-		super.validate(logger, config, cli);
+	async validate(logger, config, cli) {
+		await super.validate(logger, config, cli);
 
 		this.target = cli.argv.target;
 		this.deployType = !/^dist-/.test(this.target) && cli.argv['deploy-type'] ? cli.argv['deploy-type'] : this.deployTypes[this.target];
@@ -1498,118 +1498,118 @@ class AndroidBuilder extends Builder {
 			}
 		}
 
-		return function (callback) {
-			this.validateTiModules('android', this.deployType, function validateTiModulesCallback(err, modules) {
-				// Create a copy of the given modules found in "tiapp.xml", excluding modules that we no longer support.
-				const blacklistedModuleNames = [ 'com.soasta.touchtest' ];
-				this.modules = modules.found.filter((module) => {
-					const isBlackListed = blacklistedModuleNames.includes(module.id);
-					if (isBlackListed) {
-						this.logger.warn(`Skipping unsupported module "${module.id.cyan}"`);
-					}
-					return !isBlackListed;
-				});
-
-				for (const module of this.modules) {
-					// Flag object as either a native JAR/AAR module or a scripted CommonJS module for fast if-checks later.
-					module.native = (module.platform.indexOf('commonjs') < 0);
-
-					// For native modules, verify they are built with API version 2.0 or higher.
-					if (module.native && (~~module.manifest.apiversion < 2)) {
-						this.logger.error(`The "apiversion" for "${module.manifest.moduleid.cyan}" in the module manifest is less than version 2.`);
-						this.logger.error('The module was likely built against a Titanium SDK 1.8.0.1 or older.');
-						this.logger.error('Please use a version of the module that has "apiversion" 2 or greater');
-						this.logger.log();
-						process.exit(1);
-					}
-
-					// For CommonJS modules, verify we can find the main script to be loaded by require() method.
-					if (!module.native) {
-						// Look for legacy "<module.id>.js" script file first.
-						let jsFilePath = path.join(module.modulePath, module.id + '.js');
-						if (!fs.existsSync(jsFilePath)) {
-							// Check if require API can find the script.
-							jsFilePath = require.resolve(module.modulePath);
-							if (!fs.existsSync(jsFilePath)) {
-								this.logger.error(
-									`Module "${
-										module.id
-									}" ${
-										module.manifest.version ? `v${module.manifest.version}` : 'latest'
-									} is missing main file: ${
-										module.id
-									}.js, package.json with "main" entry, index.js, or index.json\n`
-								);
-								process.exit(1);
-							}
-						}
-					} else {
-						// Limit application build ABI to that of provided native modules.
-						this.abis = this.abis.filter(abi => {
-							if (!module.manifest.architectures.includes(abi)) {
-								this.logger.warn(`Module ${
-									module.id.cyan
-								} does not contain ${
-									abi.cyan
-								} ABI. Application will build without ${
-									abi.cyan
-								} ABI support!`);
-								return false;
-							}
-							return true;
-						});
-					}
-
-					// scan the module for any CLI hooks
-					cli.scanHooks(path.join(module.modulePath, 'hooks'));
-				}
-
-				// check for any missing module dependencies
-				let hasAddedModule = false;
-				for (const module of this.modules) {
-					if (!module.native) {
-						continue;
-					}
-
-					const timoduleXmlFile = path.join(module.modulePath, 'timodule.xml');
-					const timodule = fs.existsSync(timoduleXmlFile) ? new tiappxml(timoduleXmlFile) : undefined;
-
-					if (timodule && Array.isArray(timodule.modules)) {
-						for (let dependency of timodule.modules) {
-							if (!dependency.platform || /^android$/.test(dependency.platform)) {
-								const isMissing = !this.modules.some(function (mod) {
-									return mod.native && (mod.id === dependency.id);
-								});
-								if (isMissing) {
-									// attempt to include missing dependency
-									dependency.depended = module;
-									this.cli.tiapp.modules.push({
-										id: dependency.id,
-										version: dependency.version,
-										platform: [ 'android' ],
-										deployType: [ this.deployType ]
-									});
-									hasAddedModule = true;
-								}
-							}
-						}
-					}
-				}
-
-				// Re-validate if a module dependency was added to the modules array.
-				if (hasAddedModule) {
-					return this.validateTiModules('android', this.deployType, validateTiModulesCallback.bind(this));
-				}
-
-				callback();
-			}.bind(this));
-		}.bind(this);
+		const modules = await this.validateTiModules('android', this.deployType);
+		return this.finalizeTiModules(modules, cli);
 	}
 
-	async run(logger, config, cli, finished) {
+	async finalizeTiModules(modules, cli) {
+		// Create a copy of the given modules found in "tiapp.xml", excluding modules that we no longer support.
+		const blacklistedModuleNames = [ 'com.soasta.touchtest' ];
+		this.modules = modules.found.filter((module) => {
+			const isBlackListed = blacklistedModuleNames.includes(module.id);
+			if (isBlackListed) {
+				this.logger.warn(`Skipping unsupported module "${module.id.cyan}"`);
+			}
+			return !isBlackListed;
+		});
+
+		for (const module of this.modules) {
+			// Flag object as either a native JAR/AAR module or a scripted CommonJS module for fast if-checks later.
+			module.native = (module.platform.indexOf('commonjs') < 0);
+
+			// For native modules, verify they are built with API version 2.0 or higher.
+			if (module.native && (~~module.manifest.apiversion < 2)) {
+				this.logger.error(`The "apiversion" for "${module.manifest.moduleid.cyan}" in the module manifest is less than version 2.`);
+				this.logger.error('The module was likely built against a Titanium SDK 1.8.0.1 or older.');
+				this.logger.error('Please use a version of the module that has "apiversion" 2 or greater');
+				this.logger.log();
+				process.exit(1);
+			}
+
+			// For CommonJS modules, verify we can find the main script to be loaded by require() method.
+			if (!module.native) {
+				// Look for legacy "<module.id>.js" script file first.
+				let jsFilePath = path.join(module.modulePath, module.id + '.js');
+				if (!fs.existsSync(jsFilePath)) {
+					// Check if require API can find the script.
+					jsFilePath = require.resolve(module.modulePath);
+					if (!fs.existsSync(jsFilePath)) {
+						this.logger.error(
+							`Module "${
+								module.id
+							}" ${
+								module.manifest.version ? `v${module.manifest.version}` : 'latest'
+							} is missing main file: ${
+								module.id
+							}.js, package.json with "main" entry, index.js, or index.json\n`
+						);
+						process.exit(1);
+					}
+				}
+			} else {
+				// Limit application build ABI to that of provided native modules.
+				this.abis = this.abis.filter(abi => {
+					if (!module.manifest.architectures.includes(abi)) {
+						this.logger.warn(`Module ${
+							module.id.cyan
+						} does not contain ${
+							abi.cyan
+						} ABI. Application will build without ${
+							abi.cyan
+						} ABI support!`);
+						return false;
+					}
+					return true;
+				});
+			}
+
+			// scan the module for any CLI hooks
+			await cli.scanHooks(path.join(module.modulePath, 'hooks'));
+		}
+
+		// check for any missing module dependencies
+		let hasAddedModule = false;
+		for (const module of this.modules) {
+			if (!module.native) {
+				continue;
+			}
+
+			const timoduleXmlFile = path.join(module.modulePath, 'timodule.xml');
+			const timodule = fs.existsSync(timoduleXmlFile) ? new tiappxml(timoduleXmlFile) : undefined;
+
+			if (timodule && Array.isArray(timodule.modules)) {
+				for (let dependency of timodule.modules) {
+					if (!dependency.platform || /^android$/.test(dependency.platform)) {
+						const isMissing = !this.modules.some(function (mod) {
+							return mod.native && (mod.id === dependency.id);
+						});
+						if (isMissing) {
+							// attempt to include missing dependency
+							dependency.depended = module;
+							this.cli.tiapp.modules.push({
+								id: dependency.id,
+								version: dependency.version,
+								platform: [ 'android' ],
+								deployType: [ this.deployType ]
+							});
+							hasAddedModule = true;
+						}
+					}
+				}
+			}
+		}
+
+		// Re-validate if a module dependency was added to the modules array.
+		if (hasAddedModule) {
+			const modules = await this.validateTiModules('android', this.deployType);
+			return this.finalizeTiModules(modules, cli);
+		}
+	}
+
+	async run(logger, config, cli) {
 		try {
 			// Call the base builder's run() method.
-			super.run(logger, config, cli, finished);
+			await super.run(logger, config, cli);
 
 			// Notify plugins that we're about to begin.
 			await cli.emit('build.pre.construct', this);
@@ -1662,11 +1662,6 @@ class AndroidBuilder extends Builder {
 				this.logger.error('Build failed. Reason: Unknown');
 			}
 			process.exit(1);
-		}
-
-		// We're done. Invoke optional callback if provided.
-		if (finished) {
-			finished();
 		}
 	}
 

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -15,7 +15,7 @@ import { detect as androidDetect } from '../lib/detect.js';
 import { AndroidManifest } from '../lib/android-manifest.js';
 import appc from 'node-appc';
 import archiver from 'archiver';
-import Builder from 'node-titanium-sdk/lib/builder.js';
+import { Builder } from '../../../cli/lib/builder.js';
 import ejs from 'ejs';
 import fields from 'fields';
 import fs from 'fs-extra';
@@ -194,126 +194,119 @@ export class AndroidModuleBuilder extends Builder {
 		this.logger.info('\nMigration completed! Building module...');
 	}
 
-	validate(logger, config, cli) {
+	async validate(logger, config, cli) {
 		super.config(logger, config, cli);
-		super.validate(logger, config, cli);
+		await super.validate(logger, config, cli);
 
-		return function (finished) {
-			this.projectDir = cli.argv['project-dir'];
-			this.buildOnly = cli.argv['build-only'];
-			this.target = cli.argv['target'];
-			this.deviceId = cli.argv['device-id'];
-			this.skipBuild = cli.argv['$_'].includes('--skip-build');
+		this.projectDir = cli.argv['project-dir'];
+		this.buildOnly = cli.argv['build-only'];
+		this.target = cli.argv['target'];
+		this.deviceId = cli.argv['device-id'];
+		this.skipBuild = cli.argv['$_'].includes('--skip-build');
 
-			this.cli = cli;
-			this.logger = logger;
-			fields.setup({ colors: cli.argv.colors });
+		this.cli = cli;
+		this.logger = logger;
+		fields.setup({ colors: cli.argv.colors });
 
-			this.manifest = this.cli.manifest;
+		// cli.manifest is the module's "manifest" file, loaded by the --project-dir
+		// option's callback in cli/commands/build.js
+		this.manifest = cli.manifest;
 
-			// detect Android environment
-			androidDetect(config, { packageJson: this.packageJson }, function (androidInfo) {
-				this.androidInfo = androidInfo;
+		// detect Android environment
+		this.androidInfo = await new Promise((resolve) => {
+			androidDetect(config, { packageJson: this.packageJson }, resolve);
+		});
 
-				const targetSDKMap = {
+		const targetSDKMap = {
+			// placeholder for Gradle to use
+			[this.compileSdkVersion]: {
+				sdk: this.compileSdkVersion
+			}
+		};
+		for (const id of Object.keys(this.androidInfo.targets)) {
+			const t = this.androidInfo.targets[id];
+			if (t.type === 'platform') {
+				targetSDKMap[t.id.replace('android-', '')] = t;
+			}
+		}
 
-					// placeholder for Gradle to use
-					[this.compileSdkVersion]: {
-						sdk: this.compileSdkVersion
-					}
-				};
-				Object.keys(this.androidInfo.targets).forEach(function (id) {
-					var t = this.androidInfo.targets[id];
-					if (t.type === 'platform') {
-						targetSDKMap[t.id.replace('android-', '')] = t;
-					}
-				}, this);
+		// check the Android SDK we require to build exists
+		this.androidCompileSDK = targetSDKMap[this.compileSdkVersion];
 
-				// check the Android SDK we require to build exists
-				this.androidCompileSDK = targetSDKMap[this.compileSdkVersion];
+		// if no target SDK, then default to most recent supported/installed
+		if (!this.targetSDK) {
+			this.targetSDK = this.maxSupportedApiLevel;
+		}
+		this.androidTargetSDK = targetSDKMap[this.targetSDK];
 
-				// if no target SDK, then default to most recent supported/installed
-				if (!this.targetSDK) {
-					this.targetSDK = this.maxSupportedApiLevel;
-				}
-				this.androidTargetSDK = targetSDKMap[this.targetSDK];
+		if (!this.androidTargetSDK) {
+			this.androidTargetSDK = {
+				sdk: this.targetSDK
+			};
+		}
 
-				if (!this.androidTargetSDK) {
-					this.androidTargetSDK = {
-						sdk: this.targetSDK
-					};
-				}
+		if (this.targetSDK < this.minSDK) {
+			logger.error(`Target Android SDK version must be ${this.minSDK} or newer\n`);
+			process.exit(1);
+		}
 
-				if (this.targetSDK < this.minSDK) {
-					logger.error(`Target Android SDK version must be ${this.minSDK} or newer\n`);
-					process.exit(1);
-				}
+		if (this.maxSDK && this.maxSDK < this.targetSDK) {
+			logger.error(`Maximum Android SDK version must be greater than or equal to the target SDK ${
+				this.targetSDK
+			}, but is currently set to ${
+				this.maxSDK
+			}\n`);
+			process.exit(1);
+		}
 
-				if (this.maxSDK && this.maxSDK < this.targetSDK) {
-					logger.error(`Maximum Android SDK version must be greater than or equal to the target SDK ${
-						this.targetSDK
-					}, but is currently set to ${
-						this.maxSDK
-					}\n`);
-					process.exit(1);
-				}
+		if (this.maxSupportedApiLevel && this.targetSDK > this.maxSupportedApiLevel) {
+			// print warning that version this.targetSDK is not tested
+			logger.warn(`Building with Android SDK ${
+				String(this.targetSDK).cyan
+			} which hasn't been tested against Titanium SDK ${
+				this.titaniumSdkVersion
+			}`);
+		}
 
-				if (this.maxSupportedApiLevel && this.targetSDK > this.maxSupportedApiLevel) {
-					// print warning that version this.targetSDK is not tested
-					logger.warn(`Building with Android SDK ${
-						String(this.targetSDK).cyan
-					} which hasn't been tested against Titanium SDK ${
-						this.titaniumSdkVersion
-					}`);
-				}
+		// get javac params
+		this.javacMaxMemory = config.get('android.javac.maxMemory', '3072M');
 
-				// get javac params
-				this.javacMaxMemory = config.get('android.javac.maxMemory', '3072M');
+		// TODO remove in the next SDK
+		if (cli.timodule.properties['android.javac.maxmemory'] && cli.timodule.properties['android.javac.maxmemory'].value) {
+			logger.error('android.javac.maxmemory is deprecated and will be removed in the next version. Please use android.javac.maxMemory\n');
+			this.javacMaxMemory = cli.timodule.properties['android.javac.maxmemory'].value;
+		}
 
-				// TODO remove in the next SDK
-				if (cli.timodule.properties['android.javac.maxmemory'] && cli.timodule.properties['android.javac.maxmemory'].value) {
-					logger.error('android.javac.maxmemory is deprecated and will be removed in the next version. Please use android.javac.maxMemory\n');
-					this.javacMaxMemory = cli.timodule.properties['android.javac.maxmemory'].value;
-				}
+		if (cli.timodule.properties['android.javac.maxMemory'] && cli.timodule.properties['android.javac.maxMemory'].value) {
+			this.javacMaxMemory = cli.timodule.properties['android.javac.maxMemory'].value;
+		}
 
-				if (cli.timodule.properties['android.javac.maxMemory'] && cli.timodule.properties['android.javac.maxMemory'].value) {
-					this.javacMaxMemory = cli.timodule.properties['android.javac.maxMemory'].value;
-				}
-
-				// detect JDK
-				appc.jdk.detect(config, null, function (jdkInfo) {
-					if (!jdkInfo.version) {
-						logger.error('Unable to locate the Java Development Kit\n');
-						logger.log(`You can specify the location by setting the ${'JAVA_HOME'.cyan} environment variable.\n`);
-						process.exit(1);
-					}
-
-					if (!version.satisfies(jdkInfo.version, this.packageJson.vendorDependencies.java)) {
-						logger.error(`JDK version ${
-							jdkInfo.version
-						} detected, but only version ${
-							this.packageJson.vendorDependencies.java
-						} is supported\n`);
-						process.exit(1);
-					}
-
-					this.jdkInfo = jdkInfo;
-
-					finished();
-				}.bind(this));
-			}.bind(this));
-		}.bind(this);
+		// detect JDK
+		this.jdkInfo = await new Promise((resolve) => {
+			appc.jdk.detect(config, null, resolve);
+		});
+		if (!this.jdkInfo.version) {
+			logger.error('Unable to locate the Java Development Kit\n');
+			logger.log(`You can specify the location by setting the ${'JAVA_HOME'.cyan} environment variable.\n`);
+			process.exit(1);
+		}
+		if (!version.satisfies(this.jdkInfo.version, this.packageJson.vendorDependencies.java)) {
+			logger.error(`JDK version ${
+				this.jdkInfo.version
+			} detected, but only version ${
+				this.packageJson.vendorDependencies.java
+			} is supported\n`);
+			process.exit(1);
+		}
 	}
 
-	async run(logger, config, cli, finished) {
+	async run(logger, config, cli) {
 		try {
 			// Call the base builder's run() method.
-			super.run(logger, config, cli, finished);
+			await super.run(logger, config, cli);
 
 			// Notify plugins that we're about to begin.
-			await new Promise((resolve) => {
-				cli.emit('build.module.pre.construct', this, resolve);
-			});
+			await cli.emit('build.module.pre.construct', this);
 
 			// Update module's config files, if necessary.
 			await this.migrate();
@@ -329,9 +322,7 @@ export class AndroidModuleBuilder extends Builder {
 				await this.cleanup();
 
 				// Notify plugins that we're prepping to compile.
-				await new Promise((resolve) => {
-					cli.emit('build.module.pre.compile', this, resolve);
-				});
+				await cli.emit('build.module.pre.compile', this);
 
 				// Update module files such as "manifest" if needed.
 				await this.updateModuleFiles();
@@ -343,16 +334,12 @@ export class AndroidModuleBuilder extends Builder {
 				// Build the library and output it to "dist" directory.
 				await this.buildModuleProject();
 				// Notify plugins that the build is done.
-				await new Promise((resolve) => {
-					cli.emit('build.module.post.compile', this, resolve);
-				});
+				await cli.emit('build.module.post.compile', this);
 			}
 
 			await this.packageZip();
 
-			await new Promise((resolve) => {
-				cli.emit('build.module.finalize', this, resolve);
-			});
+			await cli.emit('build.module.finalize', this);
 
 			// Run the built module via "example" project.
 			await this.runModule(cli);
@@ -366,18 +353,7 @@ export class AndroidModuleBuilder extends Builder {
 			} else {
 				this.logger.error('Build failed. Reason: Unknown');
 			}
-
-			// Exit out with an error.
-			if (finished) {
-				finished(err);
-			} else {
-				process.exit(1);
-			}
-		}
-
-		// We're done. Invoke optional callback if provided.
-		if (finished) {
-			finished();
+			process.exit(1);
 		}
 	}
 
@@ -950,7 +926,7 @@ export class AndroidModuleBuilder extends Builder {
 		await util.promisify(appc.zip.unzip)(this.moduleZipPath, tmpProjectDir, null);
 
 		// Emit hook so modules can also alter project before launch
-		await new Promise(resolve => cli.emit('create.module.app.finalize', [ this, tmpProjectDir ], resolve));
+		await cli.emit('create.module.app.finalize', [ this, tmpProjectDir ]);
 
 		// Run the temp app.
 		this.logger.debug(`Running example project... ${tmpDir.cyan}`);

--- a/android/cli/lib/android-manifest.js
+++ b/android/cli/lib/android-manifest.js
@@ -687,7 +687,7 @@ export class AndroidManifest {
  * @private
  */
 function createManifestXmlDomDocument() {
-	const xmlDomDocument = (new DOMParser()).parseFromString('<manifest/>');
+	const xmlDomDocument = (new DOMParser()).parseFromString('<manifest/>', 'text/xml');
 	xmlDomDocument.documentElement.setAttribute('xmlns:android', 'http://schemas.android.com/apk/res/android');
 	xmlDomDocument.documentElement.setAttribute('xmlns:tools', 'http://schemas.android.com/tools');
 	return xmlDomDocument;

--- a/build/lib/test/test-test.js
+++ b/build/lib/test/test-test.js
@@ -8,29 +8,160 @@
 import { handleBuild } from './test.js';
 import { expect } from 'chai';
 import fs from 'fs-extra';
+import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { Readable } from 'node:stream';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEVICE = 'Test Device';
+
+/**
+ * Formats a line the way the CLI logs device output.
+ *
+ * @param {String} message - The message the device logged
+ * @returns {String}
+ */
+function deviceLine(message) {
+	return `[INFO] :  [${DEVICE}] ${message}`;
+}
+
+/**
+ * Builds a synthetic build log containing the markers `handleBuild()` parses.
+ *
+ * @param {Object} [opts] - Log options
+ * @param {Number} [opts.passed] - Number of passing test results to emit
+ * @param {Number} [opts.failed] - Number of failing test results to emit
+ * @param {Boolean} [opts.stop] - Emit the suite stop marker
+ * @param {String} [opts.trailer] - An extra line to append after the results
+ * @returns {String}
+ */
+function buildLog({ passed = 0, failed = 0, stop = true, trailer } = {}) {
+	const lines = [
+		'[INFO] :  Ignored build output that precedes the app starting',
+		'[INFO] :  -- Start application log ---',
+		deviceLine('OS_VERSION: 14.0')
+	];
+
+	for (let i = 0; i < passed; i++) {
+		lines.push(deviceLine(`!TEST_START: {"suite":"example","title":"passing ${i}"}`));
+		lines.push(deviceLine(`!TEST_END: {"state":"passed","duration":1,"suite":"example","title":"passing ${i}"}`));
+	}
+
+	for (let i = 0; i < failed; i++) {
+		lines.push(deviceLine(`!TEST_START: {"suite":"example","title":"failing ${i}"}`));
+		lines.push(deviceLine(`!TEST_END: {"state":"failed","duration":2,"suite":"example","title":"failing ${i}","message":"boom"}`));
+	}
+
+	if (trailer) {
+		lines.push(trailer);
+	}
+	if (stop) {
+		lines.push(deviceLine('!TEST_RESULTS_STOP!'));
+	}
+
+	return `${lines.join('\n')}\n`;
+}
+
+/**
+ * A child process stub that replays the given log on stdout.
+ *
+ * @param {String} log - The build log to replay
+ * @returns {Object}
+ */
+function createProcess(log) {
+	return {
+		stdout: Readable.from([ log ]),
+		stderr: { on: () => {} },
+		on: () => {},
+		kill: () => {}
+	};
+}
 
 describe('test.handleBuild', function () {
 	this.slow(750);
 
-	it('works', async () => {
-		// TODO: Can we interleave stderr and stdout on separate files or something?
-		const stdout = fs.createReadStream(path.join(__dirname, 'out.txt'));
-		const prc = {
-			stdout,
-			stderr: {
-				on: () => {}
-			},
-			on: () => {},
-			kill: () => {}
-		};
-		const results = await handleBuild(prc, 'emulator', __dirname, []);
-		expect(results).to.be.a('object');
+	let snapshotDir;
+
+	beforeEach(() => {
+		snapshotDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ti-test-snapshots-'));
+	});
+
+	afterEach(() => {
+		fs.removeSync(snapshotDir);
+	});
+
+	/**
+	 * Runs a log through `handleBuild()` with the replayed output silenced, since
+	 * it pipes everything it reads straight to stdout.
+	 *
+	 * @param {String} log - The build log to replay
+	 * @returns {Promise<Object>}
+	 */
+	async function runBuild(log) {
+		const write = process.stdout.write;
+		process.stdout.write = () => true;
+		try {
+			return await handleBuild(createProcess(log), 'emulator', snapshotDir, []);
+		} finally {
+			process.stdout.write = write;
+		}
+	}
+
+	it('collects the test results reported by the device', async () => {
+		const results = await runBuild(buildLog({ passed: 5, failed: 2 }));
+
+		expect(results).to.be.an('object');
 		expect(results.date).to.be.a('string'); // ISO date string
-		expect(results.results).to.have.lengthOf(5134); // 5134 test results (count of '!TEST_END:')
-		expect(results.results.filter(r => r.state === 'failed')).to.have.lengthOf(31); // 31 failed ('"state":"failed"')
+		expect(results.results).to.have.lengthOf(7);
+		expect(results.results.filter(r => r.state === 'failed')).to.have.lengthOf(2);
+		expect(results.results[0]).to.include({ state: 'passed', suite: 'example', title: 'passing 0' });
+		expect(results.results.every(r => r.device === DEVICE)).to.equal(true);
+	});
+
+	it('resolves with no results when the suite reports none', async () => {
+		const results = await runBuild(buildLog());
+
+		expect(results.results).to.deep.equal([]);
+	});
+
+	it('records an incomplete test end as a failure', async () => {
+		// a truncated !TEST_END payload that never parses as JSON
+		const log = buildLog({
+			passed: 1,
+			trailer: deviceLine('!TEST_END: {"state":"passed","suite":"example",')
+		});
+		const results = await runBuild(log);
+
+		expect(results.results).to.have.lengthOf(2);
+		const incomplete = results.results[1];
+		expect(incomplete.state).to.equal('failed');
+		expect(incomplete.message).to.equal('build/lib/test.js failed to parse reported test result');
+	});
+
+	it('rejects when the app log ends before the suite finishes', async () => {
+		const log = buildLog({ passed: 1, stop: false, trailer: '[INFO] :  -- End application log ----' });
+
+		let err;
+		try {
+			await runBuild(log);
+		} catch (e) {
+			err = e;
+		}
+
+		expect(err).to.be.an('error');
+		expect(err.message).to.equal('Failed to finish test suite before app crashed and logs ended!');
+	});
+
+	it('rejects when the app fails to install', async () => {
+		const log = buildLog({ stop: false, trailer: deviceLine('Application failed to install') });
+
+		let err;
+		try {
+			await runBuild(log);
+		} catch (e) {
+			err = e;
+		}
+
+		expect(err).to.be.an('error');
+		expect(err.message).to.equal('Failed to install test app to device/sim');
 	});
 });

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -13,6 +13,11 @@ import sprintf from 'sprintf';
 import ti from 'node-titanium-sdk';
 import tiappxml from 'node-titanium-sdk/lib/tiappxml.js';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { validatePlatformOptions } from '../lib/validate-platform-options.js';
+import { validateModuleManifest } from '../lib/validate-module-manifest.js';
+import { sdkManifest } from '../lib/sdk-manifest.js';
+import { resolvePlatform } from '../lib/resolve-platform.js';
+import { loadPlugins } from '../lib/load-plugins.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -31,7 +36,7 @@ fields.setup({
 	}
 });
 
-export const cliVersion = '>=3.2.1';
+export const cliVersion = '>=9.1.0';
 export const title = 'Build';
 export const desc = 'builds a project';
 export const extendedDesc = 'Builds an existing app or module project.';
@@ -154,7 +159,7 @@ export function config(logger, config, cli) {
 									// if they didn't explicitly set --platform and we have a platform in the manifest,
 									// then just use that and skip the platform prompting
 									if (!cli.argv.platform && manifest.platform) {
-										cli.argv.platform = ti.resolvePlatform(manifest.platform);
+										cli.argv.platform = resolvePlatform(manifest.platform);
 										conf.options.platform.required = false;
 									}
 
@@ -246,56 +251,37 @@ export function config(logger, config, cli) {
 	};
 }
 
-export function validate(logger, config, cli) {
-	// Determine if the project is an app or a module, run appropriate build command
-	if (cli.argv.type === 'module') {
-
-		// make sure the module manifest is sane
-		ti.validateModuleManifest(logger, cli, cli.manifest);
-
-		return function (finished) {
-			logger.log.init(function () {
-				const result = ti.validatePlatformOptions(logger, config, cli, 'buildModule');
-				if (result && typeof result === 'function') {
-					result(finished);
-				} else {
-					finished(result);
-				}
-			});
-		};
-
-	} else {
-
-		ti.validatePlatform(logger, cli, 'platform');
-
-		// since we need validate() to be async, we return a function in which the cli
-		// will immediately call
-		return function (finished) {
-			logger.log.init(function () {
-				function next(result) {
-					if (result !== false) {
-						// no error, load the tiapp.xml plugins
-						ti.loadPlugins(logger, config, cli, cli.argv['project-dir'], function () {
-							finished(result);
-						});
-					} else {
-						finished(result);
-					}
-				}
-
-				// loads the platform specific bulid command and runs its validate() function
-				const result = ti.validatePlatformOptions(logger, config, cli, 'build');
-				if (result && typeof result === 'function') {
-					result(next);
-				} else {
-					next(result);
-				}
-			});
-		};
+function validatePlatform(logger, cli, name) {
+	const platform = name ? cli.argv[name] : cli.argv;
+	const p = cli.argv[name] = resolvePlatform(platform);
+	if (!p || sdkManifest.platforms.indexOf(p) === -1) {
+		logger.banner();
+		logger.error(`Invalid platform "${platform}"\n`);
+		appc.string.suggest(platform, ti.targetPlatforms, logger.log);
+		logger.log(`Available platforms for SDK version ${cli.sdk && cli.sdk.name || sdkManifest.version}:`);
+		for (const p of ti.targetPlatforms) {
+			logger.log(`    ${p.cyan}`);
+		}
+		logger.log();
+		process.exit(1);
 	}
 }
 
-export async function run(logger, config, cli, finished) {
+export async function validate(logger, config, cli) {
+	// Determine if the project is an app or a module, run appropriate build command
+	if (cli.argv.type === 'module') {
+		validateModuleManifest(logger, cli, cli.manifest);
+		await logger.log.init();
+		await validatePlatformOptions(logger, config, cli, 'buildModule');
+	} else {
+		validatePlatform(logger, cli, 'platform');
+		await logger.log.init();
+		await validatePlatformOptions(logger, config, cli, 'build');
+		await loadPlugins(logger, config, cli);
+	}
+}
+
+export async function run(logger, config, cli) {
 	const buildFile = cli.argv.type === 'module' ? '_buildModule.js' : '_build.js';
 	const platform = ti.resolvePlatform(cli.argv.platform);
 	const buildModule = pathToFileURL(path.join(__dirname, '..', '..', platform, 'cli', 'commands', buildFile));
@@ -306,36 +292,32 @@ export async function run(logger, config, cli, finished) {
 		process.exit(1);
 	}
 
-	let counter = 0;
 	const { run } = await import(buildModule);
+	let delta;
 
-	run(logger, config, cli, function (err) { // eslint-disable-line security/detect-non-literal-require
-		if (!counter++) {
-			const delta = appc.time.prettyDiff(cli.startTime, Date.now());
-			if (err) {
-				logger.error(`An error occurred during build after ${delta}`);
-				if (err instanceof appc.exception) {
-					err.dump(logger.error);
-				} else if (err !== true) {
-					(err.message || err.toString()).trim().split('\n').forEach(function (msg) {
-						logger.error(msg);
-					});
-				}
-				logger.log();
-				logger.log.end();
-				process.exit(1);
-			} else {
-				// eventually all platforms will just show how long the build took since they
-				// are responsible for showing the own logging
-				if (platform !== 'iphone' || cli.argv['build-only']) {
-					logger.info(`Project built successfully in ${delta.cyan}\n`);
-				}
-				logger.log.end();
-			}
-
-			finished();
+	try {
+		await run(logger, config, cli);
+		delta = appc.time.prettyDiff(cli.startTime, Date.now());
+		// eventually all platforms will just show how long the build took since they
+		// are responsible for showing the own logging
+		if (platform !== 'iphone' || cli.argv['build-only']) {
+			logger.info(`Project built successfully in ${delta.cyan}\n`);
 		}
-	});
+		logger.log.end();
+	} catch (err) {
+		delta = appc.time.prettyDiff(cli.startTime, Date.now());
+		logger.error(`An error occurred during build after ${delta}`);
+		if (err instanceof appc.exception) {
+			err.dump(logger.error);
+		} else if (err !== true) {
+			(err.message || err.toString()).trim().split('\n').forEach(function (msg) {
+				logger.error(msg);
+			});
+		}
+		logger.log();
+		logger.log.end();
+		process.exit(1);
+	}
 }
 
 /**
@@ -400,7 +382,7 @@ function patchLogger(logger, cli) {
 		logger.padLevels = padLevels;
 	};
 
-	logger.log.init = function (callback) {
+	logger.log.init = async () => {
 		var platform = ti.resolvePlatform(cli.argv.platform),
 			buildDir = path.join(cli.argv['project-dir'], 'build');
 
@@ -423,37 +405,35 @@ function patchLogger(logger, cli) {
 			return appc.string.rpad(s, 27);
 		}
 
-		cli.env.getOSInfo(function (osInfo) {
-			logger.log([
-				new Date().toLocaleString(),
-				'',
-				styleHeading('Operating System'),
-				'  ' + rpad('Name')            + ' = ' + styleValue(osInfo.os),
-				'  ' + rpad('Version')         + ' = ' + styleValue(osInfo.osver),
-				'  ' + rpad('Architecture')    + ' = ' + styleValue(osInfo.ostype),
-				'  ' + rpad('# CPUs')          + ' = ' + styleValue(osInfo.oscpu),
-				'  ' + rpad('Memory')          + ' = ' + styleValue((osInfo.memory / 1024 / 1024 / 1024).toFixed(1) + 'GB'),
-				'',
-				styleHeading('Node.js'),
-				'  ' + rpad('Node.js Version') + ' = ' + styleValue(osInfo.node),
-				'  ' + rpad('npm Version')     + ' = ' + styleValue(osInfo.npm),
-				'',
-				styleHeading('Titanium CLI'),
-				'  ' + rpad('CLI Version')     + ' = ' + styleValue(cli.version),
-				'',
-				styleHeading('Titanium SDK'),
-				'  ' + rpad('SDK Version')     + ' = ' + styleValue(cli.argv.sdk),
-				'  ' + rpad('SDK Path')        + ' = ' + styleValue(cli.sdk.path),
-				'  ' + rpad('Target Platform') + ' = ' + styleValue(ti.resolvePlatform(cli.argv.platform)),
-				'',
-				styleHeading('Command'),
-				'  ' + styleValue(process.argv.join(' ')),
-				''
-			].join('\n'));
+		const osInfo = await cli.env.getOSInfo();
+		logger.log([
+			new Date().toLocaleString(),
+			'',
+			styleHeading('Operating System'),
+			'  ' + rpad('Name')            + ' = ' + styleValue(osInfo.os),
+			'  ' + rpad('Version')         + ' = ' + styleValue(osInfo.osver),
+			'  ' + rpad('Architecture')    + ' = ' + styleValue(osInfo.ostype),
+			'  ' + rpad('# CPUs')          + ' = ' + styleValue(osInfo.oscpu),
+			'  ' + rpad('Memory')          + ' = ' + styleValue((osInfo.memory / 1024 / 1024 / 1024).toFixed(1) + 'GB'),
+			'',
+			styleHeading('Node.js'),
+			'  ' + rpad('Node.js Version') + ' = ' + styleValue(osInfo.node),
+			'  ' + rpad('npm Version')     + ' = ' + styleValue(osInfo.npm),
+			'',
+			styleHeading('Titanium CLI'),
+			'  ' + rpad('CLI Version')     + ' = ' + styleValue(cli.version),
+			'',
+			styleHeading('Titanium SDK'),
+			'  ' + rpad('SDK Version')     + ' = ' + styleValue(cli.argv.sdk),
+			'  ' + rpad('SDK Path')        + ' = ' + styleValue(cli.sdk.path),
+			'  ' + rpad('Target Platform') + ' = ' + styleValue(ti.resolvePlatform(cli.argv.platform)),
+			'',
+			styleHeading('Command'),
+			'  ' + styleValue(process.argv.join(' ')),
+			''
+		].join('\n'));
 
-			logger.log.flush();
-			callback();
-		});
+		logger.log.flush();
 	};
 
 	logger.log.flush = function () {

--- a/cli/commands/clean.js
+++ b/cli/commands/clean.js
@@ -10,14 +10,16 @@ import ti from 'node-titanium-sdk';
 import fs from 'fs-extra';
 import path from 'node:path';
 import sprintf from 'sprintf';
-import async from 'async';
 import tiappxml from 'node-titanium-sdk/lib/tiappxml.js';
 import fields from 'fields';
 import { fileURLToPath } from 'node:url';
+import { validateModuleManifest } from '../lib/validate-module-manifest.js';
+import { validatePlatformOptions } from '../lib/validate-platform-options.js';
+import { loadPlugins } from '../lib/load-plugins.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export const cliVersion = '>=3.2.1';
+export const cliVersion = '>=9.1.0';
 export const desc = 'removes previous build directories';
 
 export function config(logger, config, cli) {
@@ -173,24 +175,12 @@ export function config(logger, config, cli) {
 	};
 }
 
-export function validate(logger, config, cli) {
+export async function validate(logger, config, cli) {
 	// Determine if the project is an app or a module, run appropriate clean command
 	if (cli.argv.type === 'module') {
-
-		// make sure the module manifest is sane
-		ti.validateModuleManifest(logger, cli, cli.manifest);
-
-		return function (finished) {
-			logger.log.init(function () {
-				const result = ti.validatePlatformOptions(logger, config, cli, 'cleanModule');
-				if (result && typeof result === 'function') {
-					result(finished);
-				} else {
-					finished(result);
-				}
-			});
-		};
-
+		validateModuleManifest(logger, cli, cli.manifest);
+		await logger.log.init();
+		await validatePlatformOptions(logger, config, cli, 'cleanModule');
 	} else {
 		let platforms = cli.argv.platforms || cli.argv.platform;
 		if (platforms) {
@@ -217,23 +207,11 @@ export function validate(logger, config, cli) {
 
 		ti.validateProjectDir(logger, cli, cli.argv, 'project-dir');
 
-		return function (finished) {
-			ti.loadPlugins(logger, config, cli, cli.argv['project-dir'], function () {
-				finished();
-			});
-		};
+		await loadPlugins(logger, config, cli);
 	}
 }
 
-export function run(logger, config, cli) {
-	function done(err) {
-		if (err) {
-			logger.error(`Failed to clean project in ${appc.time.prettyDiff(cli.startTime, Date.now())}\n`);
-		} else {
-			logger.info(`Project cleaned successfully in ${appc.time.prettyDiff(cli.startTime, Date.now())}\n`);
-		}
-	}
-
+export async function run(logger, config, cli) {
 	if (cli.argv.type === 'module') {
 		// TODO Iterate over platforms? For multi-platform modules we should handle this...
 		const platform = ti.resolvePlatform(cli.argv.platform);
@@ -246,103 +224,88 @@ export function run(logger, config, cli) {
 
 		// Now wrap the actual cleaning of the module (specific to a given platform),
 		// in hooks so a module itself could potentially do additional cleanup itself
-		cli.emit('clean.module.pre', function () {
-			cli.emit('clean.module.' + platform + '.pre', async function () {
+		await cli.emit('clean.module.pre');
+		await cli.emit(`clean.module.${platform}.pre`);
 
-				// Do the actual cleaning per-sdk _cleanModule command
-				const { run } = await import(cleanModule);
-				run(logger, config, cli, function (err) { // eslint-disable-line security/detect-non-literal-require
-					const delta = appc.time.prettyDiff(cli.startTime, Date.now());
-					if (err) {
-						logger.error(`An error occurred during clean after ${delta}`);
-						if (err instanceof appc.exception) {
-							err.dump(logger.error);
-						} else if (err !== true) {
-							(err.message || err.toString()).trim().split('\n').forEach(function (msg) {
-								logger.error(msg);
-							});
-						}
-						logger.log();
-						logger.log.end();
-						process.exit(1);
-					} else {
-						logger.log.end();
-					}
-
-					cli.emit('clean.module.' + platform + '.post', function () {
-						cli.emit('clean.module.post', function () {
-							done();
-						});
-					});
-				});
+		// Do the actual cleaning per-sdk _cleanModule command
+		const { run: cleanModule2 } = await import(cleanModule);
+		try {
+			await new Promise((resolve, reject) => {
+				cleanModule2(logger, config, cli, err => err ? reject(err) : resolve());
 			});
-		});
+		} catch (err) {
+			const delta = appc.time.prettyDiff(cli.startTime, Date.now());
+			logger.error(`An error occurred during clean after ${delta}`);
+			if (err instanceof appc.exception) {
+				err.dump(logger.error);
+			} else if (err !== true) {
+				(err.message || err.toString()).trim().split('\n').forEach(function (msg) {
+					logger.error(msg);
+				});
+			}
+			logger.log();
+			logger.log.end();
+			process.exit(1);
+		}
+		logger.log.end();
+
+		await cli.emit(`clean.module.${platform}.post`);
+		await cli.emit('clean.module.post');
 	} else {
 		const buildDir = path.join(cli.argv['project-dir'], 'build');
 
 		if (cli.argv.platforms) {
-			async.series(cli.argv.platforms.map(function (platform) {
-				return function (next) {
-					// scan platform SDK specific clean hooks
-					cli.scanHooks(path.join(__dirname, '..', '..', platform, 'cli', 'hooks'));
-					cli.emit('clean.pre', function () {
-						cli.emit('clean.' + platform + '.pre', function () {
-							var dir = path.join(buildDir, platform);
-							if (appc.fs.exists(dir)) {
-								logger.debug(`Deleting ${dir.cyan}`);
-								fs.removeSync(dir);
-							} else {
-								logger.debug(`Directory does not exist ${dir.cyan}`);
-							}
-							dir = path.join(buildDir, 'build_' + platform + '.log');
-							if (appc.fs.exists(dir)) {
-								logger.debug(`Deleting ${dir.cyan}`);
-								fs.unlinkSync(dir);
-							} else {
-								logger.debug(`Build log does not exist ${dir.cyan}`);
-							}
-							cli.emit('clean.' + platform + '.post', function () {
-								cli.emit('clean.post', function () {
-									next();
-								});
-							});
-						});
-					});
-				};
-			}), done);
+			for (const platform of cli.argv.platforms) {
+				// scan platform SDK specific clean hooks
+				await cli.scanHooks(path.join(__dirname, '..', '..', platform, 'cli', 'hooks'));
+
+				await cli.emit('clean.pre');
+				await cli.emit(`clean.${platform}.pre`);
+
+				let dir = path.join(buildDir, platform);
+				if (appc.fs.exists(dir)) {
+					logger.debug(`Deleting ${dir.cyan}`);
+					fs.removeSync(dir);
+				} else {
+					logger.debug(`Directory does not exist ${dir.cyan}`);
+				}
+
+				dir = path.join(buildDir, `build_${platform}.log`);
+				if (appc.fs.exists(dir)) {
+					logger.debug(`Deleting ${dir.cyan}`);
+					fs.unlinkSync(dir);
+				} else {
+					logger.debug(`Build log does not exist ${dir.cyan}`);
+				}
+
+				await cli.emit(`clean.${platform}.post`);
+				await cli.emit('clean.post');
+			}
 		} else if (appc.fs.exists(buildDir)) {
 			logger.debug('Deleting all platform build directories');
 
 			// scan platform SDK specific clean hooks
-			if (ti.targetPlatforms) {
-				ti.targetPlatforms.forEach(function (platform) {
-					cli.scanHooks(path.join(__dirname, '..', '..', platform, 'cli', 'hooks'));
-				});
+			for (const platform of ti.targetPlatforms || []) {
+				await cli.scanHooks(path.join(__dirname, '..', '..', platform, 'cli', 'hooks'));
 			}
 
-			cli.emit('clean.pre', function () {
-				async.series(fs.readdirSync(buildDir).map(function (dir) {
-					return function (next) {
-						var file = path.join(buildDir, dir);
-						cli.emit('clean.' + dir + '.pre', function () {
-							logger.debug(`Deleting ${file.cyan}`);
-							fs.removeSync(file);
-							cli.emit('clean.' + dir + '.post', function () {
-								next();
-							});
-						});
-					};
-				}), function () {
-					cli.emit('clean.post', function () {
-						done();
-					});
-				});
-			});
+			await cli.emit('clean.pre');
+
+			for (const name of fs.readdirSync(buildDir)) {
+				const file = path.join(buildDir, name);
+				await cli.emit(`clean.${name}.pre`);
+				logger.debug(`Deleting ${file.cyan}`);
+				fs.removeSync(file);
+				await cli.emit(`clean.${name}.post`);
+			}
+
+			await cli.emit('clean.post');
 		} else {
 			logger.debug(`Directory does not exist ${buildDir.cyan}`);
-			done();
 		}
 	}
+
+	logger.info(`Project cleaned successfully in ${appc.time.prettyDiff(cli.startTime, Date.now())}\n`);
 }
 
 /**
@@ -407,7 +370,7 @@ function patchLogger(logger, cli) {
 		logger.padLevels = padLevels;
 	};
 
-	logger.log.init = function (callback) {
+	logger.log.init = async () => {
 		var platform = ti.resolvePlatform(cli.argv.platform),
 			buildDir = path.join(cli.argv['project-dir'], 'build');
 
@@ -430,37 +393,35 @@ function patchLogger(logger, cli) {
 			return appc.string.rpad(s, 27);
 		}
 
-		cli.env.getOSInfo(function (osInfo) {
-			logger.log([
-				new Date().toLocaleString(),
-				'',
-				styleHeading('Operating System'),
-				'  ' + rpad('Name')            + ' = ' + styleValue(osInfo.os),
-				'  ' + rpad('Version')         + ' = ' + styleValue(osInfo.osver),
-				'  ' + rpad('Architecture')    + ' = ' + styleValue(osInfo.ostype),
-				'  ' + rpad('# CPUs')          + ' = ' + styleValue(osInfo.oscpu),
-				'  ' + rpad('Memory')          + ' = ' + styleValue((osInfo.memory / 1024 / 1024 / 1024).toFixed(1) + 'GB'),
-				'',
-				styleHeading('Node.js'),
-				'  ' + rpad('Node.js Version') + ' = ' + styleValue(osInfo.node),
-				'  ' + rpad('npm Version')     + ' = ' + styleValue(osInfo.npm),
-				'',
-				styleHeading('Titanium CLI'),
-				'  ' + rpad('CLI Version')     + ' = ' + styleValue(cli.version),
-				'',
-				styleHeading('Titanium SDK'),
-				'  ' + rpad('SDK Version')     + ' = ' + styleValue(cli.argv.sdk),
-				'  ' + rpad('SDK Path')        + ' = ' + styleValue(cli.sdk.path),
-				'  ' + rpad('Target Platform') + ' = ' + styleValue(ti.resolvePlatform(cli.argv.platform)),
-				'',
-				styleHeading('Command'),
-				'  ' + styleValue(process.argv.join(' ')),
-				''
-			].join('\n'));
+		const osInfo = await cli.env.getOSInfo();
+		logger.log([
+			new Date().toLocaleString(),
+			'',
+			styleHeading('Operating System'),
+			'  ' + rpad('Name')            + ' = ' + styleValue(osInfo.os),
+			'  ' + rpad('Version')         + ' = ' + styleValue(osInfo.osver),
+			'  ' + rpad('Architecture')    + ' = ' + styleValue(osInfo.ostype),
+			'  ' + rpad('# CPUs')          + ' = ' + styleValue(osInfo.oscpu),
+			'  ' + rpad('Memory')          + ' = ' + styleValue((osInfo.memory / 1024 / 1024 / 1024).toFixed(1) + 'GB'),
+			'',
+			styleHeading('Node.js'),
+			'  ' + rpad('Node.js Version') + ' = ' + styleValue(osInfo.node),
+			'  ' + rpad('npm Version')     + ' = ' + styleValue(osInfo.npm),
+			'',
+			styleHeading('Titanium CLI'),
+			'  ' + rpad('CLI Version')     + ' = ' + styleValue(cli.version),
+			'',
+			styleHeading('Titanium SDK'),
+			'  ' + rpad('SDK Version')     + ' = ' + styleValue(cli.argv.sdk),
+			'  ' + rpad('SDK Path')        + ' = ' + styleValue(cli.sdk.path),
+			'  ' + rpad('Target Platform') + ' = ' + styleValue(ti.resolvePlatform(cli.argv.platform)),
+			'',
+			styleHeading('Command'),
+			'  ' + styleValue(process.argv.join(' ')),
+			''
+		].join('\n'));
 
-			logger.log.flush();
-			callback();
-		});
+		logger.log.flush();
 	};
 
 	logger.log.flush = function () {

--- a/cli/commands/create.js
+++ b/cli/commands/create.js
@@ -21,7 +21,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export const cliVersion = '>=3.2.1';
+export const cliVersion = '>=9.1.0';
 export const title = 'Create';
 export const desc = 'creates a new project';
 export const extendedDesc = `Creates a new Titanium application, native module, or Apple Watch™ app.

--- a/cli/commands/project.js
+++ b/cli/commands/project.js
@@ -8,8 +8,9 @@
 import path from 'node:path';
 import ti from 'node-titanium-sdk';
 import appc from 'node-appc';
+import { loadPlugins } from '../lib/load-plugins.js';
 
-export const cliVersion = '>=3.2.1';
+export const cliVersion = '>=9.1.0';
 export const desc = 'get and set tiapp.xml settings';
 export const extendedDesc = `Get and set tiapp.xml settings.
 
@@ -53,7 +54,7 @@ export function config(logger, config) {
 	};
 }
 
-export function validate(logger, config, cli) {
+export async function validate(logger, config, cli) {
 	ti.validateProjectDir(logger, cli, cli.argv, 'project-dir');
 
 	// Validate the key, if it exists
@@ -65,9 +66,7 @@ export function validate(logger, config, cli) {
 		}
 	}
 
-	return function (finished) {
-		ti.loadPlugins(null, config, cli, cli.argv['project-dir'], finished, cli.argv.output !== 'report' || cli.argv._.length, false);
-	};
+	await loadPlugins(null, config, cli, cli.argv.output !== 'report' || cli.argv._.length, false);
 }
 
 export function run(logger, config, cli, finished) {

--- a/cli/lib/builder.js
+++ b/cli/lib/builder.js
@@ -1,0 +1,515 @@
+import {
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	symlinkSync,
+	unlinkSync,
+	writeFileSync,
+	readFileSync,
+	realpathSync,
+	statSync
+} from 'node:fs';
+import { basename, dirname, extname, join, parse } from 'node:path';
+import { createHash } from 'node:crypto';
+import { rename } from 'node:fs/promises';
+import appc from 'node-appc';
+import { sdkPath, sdkName, sdkManifest } from './sdk-manifest.js';
+
+/**
+ * The base class for platform specific build commands. This ensures some
+ * commonality between build commands so that hooks can consistently
+ * access build properties.
+ *
+ * General usage is to extend the Builder class and override the config(),
+ * validate(), and run() methods:
+ *
+ * @example
+ * ```js
+ * import { Builder } from '../../cli/lib/builder.js';
+ *
+ * class SomePlatformBuilder extends Builder {
+ *     config(logger, config, cli) {
+ *         super.config(logger, config, cli);
+ *         // TODO: platform specific config code goes here
+ *     }
+ *
+ *     validate(logger, config, cli) {
+ *         super.validate(logger, config, cli);
+ *         // TODO: platform specific validate code goes here
+ *     }
+ *
+ *     run(logger, config, cli, finished) {
+ *         super.run();
+ *         // TODO: platform specific run code goes here
+ *         finished();
+ *     }
+ * }
+ * ```
+ */
+export class Builder {
+	conf = {};
+	buildDirFiles = {};
+
+	/**
+	 * Constructs the build state. This needs to be explicitly called from the
+	 * derived builder's constructor.
+	 *
+	 * @param {Module} buildModule The "module" variable from the build command file
+	 */
+	constructor(buildModule) {
+		this.titaniumSdkPath = sdkPath;
+		this.titaniumSdkName = sdkName;
+		this.titaniumSdkVersion = sdkManifest.version;
+		this.sdkManifest = sdkManifest;
+		this.platformPath = this.locatePlatformPath(buildModule);
+		this.platformName = basename(this.platformPath);
+		this.globalModulesPath = join(sdkPath, '..', '..', '..', 'modules');
+		this.packageJson = JSON.parse(readFileSync(join(this.platformPath, 'package.json'), 'utf8'));
+	}
+
+	/**
+	 * Locates the platform path for the given build module.
+	 *
+	 * @param {Module} buildModule The "module" variable from the build command file
+	 * @returns {String} The platform path
+	 */
+	locatePlatformPath(buildModule) {
+		let dir = dirname(buildModule.filename);
+		const { root } = parse(dir);
+		while (dir !== root) {
+			if (existsSync(join(dir, 'package.json'))) {
+				return dir;
+			}
+			dir = dirname(dir);
+		}
+		return null;
+	}
+
+	/**
+	 * Defines common variables prior to running the build's config(). This super
+	 * function should be called prior to the platform-specific build command's config().
+	 *
+	 * @param {Object} logger - The logger instance
+	 * @param {Object} config - The CLI config
+	 * @param {Object} cli - The CLI instance
+	 */
+	config(logger, config, cli) {
+		// note: this function must be sync!
+		this.logger = logger;
+		this.config = config;
+		this.cli = cli;
+		this.symlinkFilesOnCopy = false;
+		this.ignoreDirs = new RegExp(config.get('cli.ignoreDirs'));
+		this.ignoreFiles = new RegExp(config.get('cli.ignoreFiles'));
+	}
+
+	/**
+	 * Validation stub function. Meant to be overwritten.
+	 *
+	 * @param {Object} logger - The logger instance
+	 * @param {Object} config - The CLI config
+	 * @param {Object} cli - The CLI instance
+	 */
+	async validate(_logger, _config, cli) {
+		this.tiapp = cli.tiapp;
+		this.timodule = cli.timodule;
+		this.projectDir = cli.argv['project-dir'];
+		this.buildDir = join(this.projectDir, 'build', this.platformName);
+
+		this.defaultIcons = [
+			join(this.projectDir, `DefaultIcon-${this.platformName}.png`),
+			join(this.projectDir, 'DefaultIcon.png')
+		];
+	}
+
+	/**
+	 * Defines common variables prior to running the build. This super function
+	 * should be called prior to the platform-specific build command's run().
+	 *
+	 * @param {Object} _logger - The logger instance
+	 * @param {Object} _config - The CLI config
+	 * @param {Object} _cli - The CLI instance
+	 */
+	async run(_logger, _config, _cli) {
+		const buildDirFiles = {};
+		this.buildDirFiles = buildDirFiles;
+
+		// walk the entire build dir and build a map of all files
+		if (existsSync(this.buildDir)) {
+			this.logger.trace('Snapshotting build directory');
+
+			// use iterative approach with a stack to avoid deep recursion
+			const dirsToProcess = [ this.buildDir ];
+
+			while (dirsToProcess.length > 0) {
+				const currentDir = dirsToProcess.pop();
+				for (const name of readdirSync(currentDir)) {
+					const file = join(currentDir, name).normalize();
+					try {
+						const stat = lstatSync(file);
+						if (stat.isDirectory()) {
+							dirsToProcess.push(file);
+						} else {
+							buildDirFiles[file] = stat;
+						}
+					} catch {
+						buildDirFiles[file] = true;
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Removes a file from the buildDirFiles map.
+	 *
+	 * @param {String} file - The file to unmark.
+	 */
+	unmarkBuildDirFile(file) {
+		delete this.buildDirFiles[file.normalize()];
+	}
+
+	/**
+	 * Removes all paths from the buildDirFiles map that start with the specified path.
+	 *
+	 * @param {String} dir - The path prefix to unmark files.
+	 */
+	unmarkBuildDirFiles(dir) {
+		if (dir.endsWith('*')) {
+			dir = dir.substring(0, dir.length - 1);
+		} else if (!dir.endsWith('/')) {
+			dir += '/';
+		}
+		dir = dir.normalize();
+		for (const file of Object.keys(this.buildDirFiles)) {
+			if (file.startsWith(dir)) {
+				delete this.buildDirFiles[file];
+			}
+		}
+	}
+
+	/**
+	 * Copies or symlinks a file to the specified destination.
+	 *
+	 * @param {String} src - The file to copy.
+	 * @param {String} dest - The destination of the file.
+	 * @param {Object} [opts] - An object containing various options.
+	 * @param {Boolean} [opts.forceCopy] - When true, forces the file to be copied and not symlinked.
+	 * @param {Boolean} [opts.forceSymlink] - When true, ignores `opts.contents` and `opts.forceCopy` and symlinks the `src` to the `dest`.
+	 * @param {Buffer|String} [opts.contents] - The contents to write to the file instead of reading the specified source file.
+	 */
+	copyFileSync(src, dest, opts = {}) {
+		const parent = dirname(dest);
+		const exists = existsSync(dest);
+
+		mkdirSync(parent, { recursive: true });
+
+		if (!opts.forceSymlink && (opts.forceCopy || !this.symlinkFilesOnCopy || opts.contents)) {
+			if (exists) {
+				this.logger.debug(`Overwriting ${src} => ${dest}`);
+				unlinkSync(dest);
+			} else {
+				this.logger.debug(`Copying ${src} => ${dest}`);
+			}
+			writeFileSync(dest, opts.contents || readFileSync(src));
+			return true;
+
+		} else if (!exists || (lstatSync(dest).isSymbolicLink() && realpathSync(dest) !== src)) {
+			if (exists) {
+				unlinkSync(dest);
+			}
+			this.logger.debug(`Symlinking ${src} => ${dest}`);
+			symlinkSync(src, dest);
+			return true;
+		}
+	}
+
+	/**
+	 * Copies or symlinks a file to the specified destination.
+	 *
+	 * @param {String} src - The directory to copy.
+	 * @param {String} dest - The destination of the files.
+	 * @param {Object} [opts] - An object containing various options.
+	 * @param {RegExp} [opts.rootIgnoreDirs] - A regular expression of directories to ignore only in the root directory.
+	 * @param {RegExp} [opts.ignoreDirs] - A regular expression of directories to ignore.
+	 * @param {RegExp} [opts.ignoreFiles] - A regular expression of files to ignore.
+	 * @param {Function} [opts.beforeCopy] - A function called before copying the file. This function can abort the copy or modify the contents being copied.
+	 * @param {Boolean} [opts.forceCopy] - When true, forces the file to be copied and not symlinked.
+	 * @param {Function} [opts.afterCopy] - A function called with the result of the file being copied.
+	 */
+	copyDirSync(src, dest, opts = {}) {
+		if (!existsSync(src)) {
+			return;
+		}
+
+		const copy = (src, dest, isRootDir) => {
+			mkdirSync(dest, { recursive: true });
+
+			for (const name of readdirSync(src)) {
+				const srcFile = join(src, name);
+				const destFile = join(dest, name);
+
+				// skip broken symlinks
+				if (!existsSync(srcFile)) {
+					continue;
+				}
+
+				const srcStat = statSync(srcFile);
+				if (srcStat.isDirectory()) {
+					// we are copying a subdirectory
+					if ((isRootDir && opts.rootIgnoreDirs && opts.rootIgnoreDirs.test(name)) || (opts.ignoreDirs && opts.ignoreDirs.test(name))) {
+						// ignoring directory
+					} else {
+						copy(srcFile, destFile);
+					}
+					continue;
+				}
+
+				// we're copying a file, check if we should ignore it
+				if (opts.ignoreFiles && opts.ignoreFiles.test(name)) {
+					continue;
+				}
+
+				if (typeof opts.beforeCopy === 'function') {
+					const result = opts.beforeCopy(srcFile, destFile, srcStat);
+					if (result === null) {
+						continue; // skip
+					} else if (result !== undefined) {
+						this.logger.debug(`Writing ${srcFile} => ${destFile}`);
+						writeFileSync(destFile, result);
+						continue;
+					}
+					// fall through and copy the file normally
+				}
+
+				const result = this.copyFileSync(srcFile, destFile, opts);
+				if (typeof opts.afterCopy === 'function') {
+					opts.afterCopy(srcFile, destFile, srcStat, result);
+				}
+			}
+		};
+		copy(src, dest, true);
+	}
+
+	/**
+	 * Validates that all required Titanium Modules defined in the tiapp.xml are
+	 * installed.
+	 *
+	 *
+	 * This function is intended to be called asynchronously from the validate()
+	 * implementation. In other words, validate() should return a function that
+	 * calls this function.
+	 *
+	 * Note: This function will forcefully exit the application on error!
+	 *
+	 * @param {String|Array} platformName - One or more platform names to use when finding Titanium modules
+	 * @param {String} deployType - The deployment type (development, test, production)
+	 */
+	async validateTiModules(platformName, deployType) {
+		const moduleSearchPaths = [ this.projectDir ];
+		const customSDKPaths = this.config.get('paths.sdks');
+		const customModulePaths = this.config.get('paths.modules');
+
+		function addSearchPath(p) {
+			p = appc.fs.resolvePath(p);
+			if (existsSync(p) && !moduleSearchPaths.includes(p)) {
+				moduleSearchPaths.push(p);
+			}
+		}
+
+		for (const p of this.cli.env.os.sdkPaths || []) {
+			addSearchPath(p);
+		}
+		if (Array.isArray(customSDKPaths)) {
+			for (const p of customSDKPaths) {
+				addSearchPath(p);
+			}
+		}
+		if (Array.isArray(customModulePaths)) {
+			for (const p of customModulePaths) {
+				addSearchPath(p);
+			}
+		}
+
+		const modules = await findTiModules(this.cli.tiapp.modules, platformName, deployType, this.sdkManifest, moduleSearchPaths, this.logger);
+
+		if (modules.missing.length) {
+			this.logger.error('Could not find all required Titanium Modules:');
+			for (const m of modules.missing) {
+				this.logger.error(`   id: ${m.id}\t version: ${m.version || 'latest'}\t platform: ${m.platform}\t deploy-type: ${m.deployType}`);
+			}
+			this.logger.log();
+			process.exit(1);
+		}
+
+		if (modules.incompatible.length) {
+			this.logger.error('Found incompatible Titanium Modules:');
+			for (const m of modules.incompatible) {
+				this.logger.error(`   id: ${m.id}\t version: ${m.version || 'latest'}\t platform: ${m.platform}\t min sdk: ${m.manifest && m.manifest.minsdk || '?'}`);
+			}
+			this.logger.log();
+			process.exit(1);
+		}
+
+		if (modules.conflict.length) {
+			this.logger.error('Found conflicting Titanium modules:');
+			for (const m of modules.conflict) {
+				this.logger.error(`   Titanium module "${m.id}" requested for both Android and CommonJS platforms, but only one may be used at a time.`);
+			}
+			this.logger.log();
+			process.exit(1);
+		}
+
+		return modules;
+	}
+
+	/**
+	 * Returns the hexadecimal md5 hash of a string.
+	 *
+	 * @param {String} str - The string to hash
+	 *
+	 * @returns {String}
+	 */
+	hash(str) {
+		return createHash('md5').update(str || '').digest('hex');
+	}
+
+	/**
+	 * Generates missing app icons based on the DefaultIcon.png.
+	 *
+	 * @param {Array<Object>} icons - An array of objects describing the icon size to generate and the destination
+	 */
+	async generateAppIcons(icons) {
+		const requiredMissing = icons.filter(icon => icon.required).length;
+		let size = null;
+
+		const printMissing = (logger, all) => {
+			for (const icon of icons) {
+				if (all || size === null || icon.width > size.width) {
+					logger(`  ${icon.description} - size: ${icon.width}x${icon.height}`);
+				}
+			}
+		};
+
+		const fail = () => {
+			this.logger.error('Unable to create missing icons:');
+			printMissing(this.logger.error);
+			throw new Error('Unable to create missing icons');
+		};
+
+		let iconLabels;
+		if (this.defaultIcons.length > 2) {
+			const labels = this.defaultIcons.map(icon => `"${basename(icon)}"`);
+			const last = labels.pop();
+			iconLabels = `${labels.join(', ')}, or ${last}`;
+		} else {
+			iconLabels = this.defaultIcons.map(icon => `"${basename(icon)}"`).join(' or ');
+		}
+
+		const defaultIcon = this.defaultIcons.find(icon => existsSync(icon));
+
+		if (!defaultIcon) {
+			if (requiredMissing === 0) {
+				if (icons.length === 1) {
+					this.logger.warn('There is a missing app icon, but it is not required');
+				} else {
+					this.logger.warn('There are missing app icons, but they are not required');
+				}
+				this.logger.warn(`You can either create the missing icons below or create an image named ${iconLabels} in the root of your project`);
+				this.logger.warn('If the DefaultIcon.png image is present, the build will use it to generate all missing icons');
+				this.logger.warn('It is highly recommended that the DefaultIcon.png be 1024x1024');
+				printMissing(this.logger.warn);
+				return;
+			}
+
+			if (icons.length === 1) {
+				this.logger.error('There is a missing required app icon');
+			} else {
+				this.logger.error('There are missing required app icons');
+			}
+			this.logger.error(`You must either create the missing icons below or create an image named ${iconLabels} in the root of your project`);
+			this.logger.error('If the DefaultIcon.png image is present, the build will use it to generate all missing icons');
+			this.logger.error('It is highly recommended that the DefaultIcon.png be 1024x1024');
+			return fail();
+		}
+
+		const contents = readFileSync(defaultIcon);
+		size = appc.image.pngInfo(contents);
+
+		if (size.width !== size.height) {
+			this.logger.error(`The ${defaultIcon} is ${size.width}x${size.height}, however the width and height must be equal`);
+			this.logger.error(`It is highly recommended that the ${defaultIcon} be 1024x1024`);
+			return fail();
+		}
+
+		this.logger.debug(`Found ${defaultIcon} (${size.width}x${size.height})`);
+		if (icons.length === 1) {
+			this.logger.info('Missing 1 app icon, generating missing icon');
+		} else {
+			this.logger.info(`Missing ${icons.length} app icons, generating missing icons`);
+		}
+		printMissing(this.logger.info, true);
+
+		const filesToRename = [];
+		let minRequiredSize = null;
+		for (let i = 0; i < icons.length; i++) {
+			const icon = icons[i];
+			if (icon.required) {
+				if (minRequiredSize === null || icon.width > minRequiredSize) {
+					minRequiredSize = icon.width;
+				}
+			} else if (icon.width > size.width) {
+				// default icon isn't big enough, so we just skip this image
+				this.logger.warn(`${defaultIcon} (${size.width}x${size.height}) is not large enough to generate missing icon "${basename(icon.file)}" (${icon.width}x${icon.height}), skipping`);
+				icons.splice(i--, 1);
+				continue;
+			}
+			if (!extname(icon.file)) {
+				// the file doesn't have an extension, so we need to temporarily set
+				// one so that the image resizer doesn't blow up
+				filesToRename.push({
+					from: icon.file + '.png',
+					to: icon.file
+				});
+				icon.file += '.png';
+			}
+		}
+
+		if (minRequiredSize !== null && size.width < minRequiredSize) {
+			this.logger.error(`The ${defaultIcon} must be at least ${minRequiredSize}x${minRequiredSize}`);
+			this.logger.error(`It is highly recommended that the ${defaultIcon} be 1024x1024`);
+			return fail();
+		}
+
+		try {
+			await resizeImage(defaultIcon, icons, this.logger);
+		} catch (error) {
+			this.logger.error(error);
+			this.logger.log();
+			process.exit(1);
+		}
+
+		for (const file of filesToRename) {
+			await rename(file.from, file.to);
+		}
+	}
+}
+
+function findTiModules(modules, platformName, deployType, manifest, searchPaths, logger) {
+	return new Promise(resolve => {
+		appc.timodule.find(modules, platformName, deployType, manifest, searchPaths, logger, resolve);
+	});
+}
+
+function resizeImage(src, dest, logger) {
+	return new Promise((resolve, reject) => {
+		appc.image.resize(src, dest, (error) => {
+			if (error) {
+				reject(error);
+			} else {
+				resolve();
+			}
+		}, logger);
+	});
+}

--- a/cli/lib/load-plugins.js
+++ b/cli/lib/load-plugins.js
@@ -1,0 +1,68 @@
+import { join, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import appc from 'node-appc';
+
+export async function loadPlugins(logger, config, cli, silent = false, compact = true) {
+	const projectDir = cli.argv['project-dir'];
+	const searchPaths = {
+		project: [ join(projectDir, 'plugins') ],
+		config: [],
+		global: []
+	};
+	let confPaths = config.get('paths.plugins');
+	const defaultInstallLocation = cli.env.installPath;
+	const sdkLocations = cli.env.os.sdkPaths.map(p => appc.fs.resolvePath(p));
+
+	// set our paths from the config file
+	if (!Array.isArray(confPaths)) {
+		confPaths = [ confPaths ];
+	}
+	for (let p of confPaths) {
+		if (!p) {
+			continue;
+		}
+		p = appc.fs.resolvePath(p);
+		if (existsSync(p) && !searchPaths.project.includes(p) && !searchPaths.config.includes(p)) {
+			searchPaths.config.push(p);
+		}
+	}
+
+	// add any plugins from various sdk locations
+	if (!sdkLocations.includes(defaultInstallLocation)) {
+		sdkLocations.push(defaultInstallLocation);
+	}
+	if (cli.sdk) {
+		sdkLocations.push(resolve(cli.sdk.path, '..', '..', '..'));
+	}
+	for (let p of sdkLocations) {
+		p = appc.fs.resolvePath(p, 'plugins');
+		if (existsSync(p) && !searchPaths.project.includes(p) && !searchPaths.config.includes(p) && !searchPaths.global.includes(p)) {
+			searchPaths.global.push(p);
+		}
+	}
+
+	// find all hooks for active plugins
+	const plugins = await new Promise((resolve) => appc.tiplugin.find(cli.tiapp.plugins, searchPaths, config, logger, resolve));
+	if (plugins.missing.length) {
+		if (logger) {
+			logger.error('Could not find all required Titanium plugins:');
+			for (const m of plugins.missing) {
+				logger.error(`   id: ${m.id}\t version: ${m.version}`);
+			}
+			logger.log();
+		}
+		process.exit(1);
+	}
+
+	if (plugins.found.length) {
+		for (const plugin of plugins.found) {
+			await cli.scanHooks(resolve(plugin.pluginPath, 'hooks'));
+		}
+	} else if (logger) {
+		logger.debug('No project level plugins to load');
+	}
+
+	if (!silent) {
+		await cli.emit('cli:check-plugins', { compact });
+	}
+}

--- a/cli/lib/resolve-platform.js
+++ b/cli/lib/resolve-platform.js
@@ -1,0 +1,9 @@
+export const platformAliases = {
+	// add additional aliases here for new platforms
+	ipad: 'iphone',
+	ios: 'iphone'
+};
+
+export function resolvePlatform(platform) {
+	return platformAliases[platform] || platform;
+}

--- a/cli/lib/sdk-manifest.js
+++ b/cli/lib/sdk-manifest.js
@@ -1,0 +1,32 @@
+import { basename, dirname, join, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const sdkPath = resolve(__dirname, '..', '..');
+export const sdkName = basename(sdkPath);
+
+/**
+ * Loads the SDK's `manifest.json`. This file is generated when the SDK is
+ * packaged, so when running from a source checkout (i.e. tests) we derive an
+ * equivalent from `package.json` instead of blowing up on import.
+ *
+ * @returns {Object} The SDK manifest
+ */
+function loadSdkManifest() {
+	const manifestPath = join(sdkPath, 'manifest.json');
+	if (existsSync(manifestPath)) {
+		return JSON.parse(readFileSync(manifestPath, 'utf8'));
+	}
+
+	const { version, moduleApiVersion } = JSON.parse(readFileSync(join(sdkPath, 'package.json'), 'utf8'));
+	return {
+		name: version,
+		version,
+		moduleAPIVersion: moduleApiVersion,
+		platforms: [ 'android', 'iphone' ].filter(p => existsSync(join(sdkPath, p)))
+	};
+}
+
+export const sdkManifest = loadSdkManifest();

--- a/cli/lib/validate-module-manifest.js
+++ b/cli/lib/validate-module-manifest.js
@@ -1,0 +1,30 @@
+import { resolvePlatform } from './resolve-platform.js';
+
+export function validateModuleManifest(logger, cli, manifest) {
+	const requiredModuleKeys = [
+		'name',
+		'version',
+		'moduleid',
+		'description',
+		'copyright',
+		'license',
+		'platform',
+		'minsdk',
+		'architectures'
+	];
+
+	// check if all the required module keys are in the list
+	for (const key of requiredModuleKeys) {
+		if (!manifest[key]) {
+			logger.error(`Missing required manifest key "${key}"`);
+			logger.log();
+			process.exit(1);
+		}
+	}
+
+	if (cli.argv.platform !== resolvePlatform(manifest.platform)) {
+		logger.error(`Unable to find "${cli.argv.platform}" module`);
+		logger.log();
+		process.exit(1);
+	}
+}

--- a/cli/lib/validate-platform-options.js
+++ b/cli/lib/validate-platform-options.js
@@ -1,0 +1,28 @@
+import { dirname, join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { sdkManifest } from './sdk-manifest.js';
+import { fileURLToPath } from 'node:url';
+import { resolvePlatform } from './resolve-platform.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export async function validatePlatformOptions(logger, config, cli, commandName) {
+	const platform = resolvePlatform(cli.argv.platform);
+	const platformCommand = join(
+		__dirname,
+		'../..',
+		sdkManifest.platforms[sdkManifest.platforms.indexOf(platform)],
+		'cli',
+		'commands',
+		`_${commandName}.js`
+	);
+
+	if (!existsSync(platformCommand)) {
+		return;
+	}
+
+	const command = await import(platformCommand);
+	if (typeof command?.validate === 'function') {
+		await command.validate(logger, config, cli);
+	}
+}

--- a/cli/tests/test-clean-run.js
+++ b/cli/tests/test-clean-run.js
@@ -1,0 +1,130 @@
+/*
+ * Titanium SDK
+ * Copyright TiDev, Inc. 04/07/2022-Present
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+import { expect } from 'chai';
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import { run } from '../commands/clean.js';
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 5));
+
+const noopLogger = {
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+	log() {}
+};
+
+/**
+ * A CLI stub whose hooks and hook scans settle asynchronously, so anything that
+ * fires them without awaiting shows up as a missing/out-of-order event.
+ *
+ * @param {Object} argv - The argv to expose to the command
+ * @returns {Object}
+ */
+function createCLI(argv) {
+	const events = [];
+	return {
+		argv,
+		startTime: Date.now(),
+		events,
+		async emit(name) {
+			await tick();
+			events.push(name);
+		},
+		async scanHooks(dir) {
+			await tick();
+			events.push(`scan:${path.basename(path.dirname(path.dirname(dir)))}`);
+		}
+	};
+}
+
+describe('clean run()', () => {
+	let projectDir;
+	let buildDir;
+
+	beforeEach(() => {
+		projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ti-clean-'));
+		buildDir = path.join(projectDir, 'build');
+		for (const platform of [ 'android', 'iphone' ]) {
+			fs.ensureDirSync(path.join(buildDir, platform));
+			fs.writeFileSync(path.join(buildDir, `build_${platform}.log`), 'log');
+		}
+	});
+
+	afterEach(() => {
+		fs.removeSync(projectDir);
+	});
+
+	it('completes every platform sequence before resolving', async () => {
+		const cli = createCLI({ 'project-dir': projectDir, platforms: [ 'android', 'iphone' ] });
+
+		await run(noopLogger, {}, cli);
+
+		// each platform runs its full pre/post hook sequence, in order, one after another
+		expect(cli.events).to.deep.equal([
+			'scan:android', 'clean.pre', 'clean.android.pre', 'clean.android.post', 'clean.post',
+			'scan:iphone', 'clean.pre', 'clean.iphone.pre', 'clean.iphone.post', 'clean.post'
+		]);
+	});
+
+	it('removes each platform build directory and log before resolving', async () => {
+		const cli = createCLI({ 'project-dir': projectDir, platforms: [ 'android', 'iphone' ] });
+
+		await run(noopLogger, {}, cli);
+
+		for (const platform of [ 'android', 'iphone' ]) {
+			expect(fs.existsSync(path.join(buildDir, platform)), `${platform} build dir`).to.equal(false);
+			expect(fs.existsSync(path.join(buildDir, `build_${platform}.log`)), `${platform} log`).to.equal(false);
+		}
+	});
+
+	it('cleans every build subdirectory when no platforms are given', async () => {
+		const cli = createCLI({ 'project-dir': projectDir, platforms: null });
+
+		await run(noopLogger, {}, cli);
+
+		expect(cli.events).to.include('clean.pre');
+		expect(cli.events).to.include('clean.android.pre');
+		expect(cli.events).to.include('clean.android.post');
+		expect(cli.events.at(-1)).to.equal('clean.post');
+		expect(fs.readdirSync(buildDir)).to.deep.equal([]);
+	});
+
+	it('propagates a rejected hook instead of reporting success', async () => {
+		const cli = createCLI({ 'project-dir': projectDir, platforms: [ 'android' ] });
+		cli.emit = async name => {
+			if (name === 'clean.android.pre') {
+				throw new Error('hook exploded');
+			}
+			cli.events.push(name);
+		};
+
+		let err;
+		try {
+			await run(noopLogger, {}, cli);
+		} catch (e) {
+			err = e;
+		}
+
+		expect(err).to.be.an('error');
+		expect(err.message).to.equal('hook exploded');
+		// the build dir must survive, since cleaning never got past the hook
+		expect(fs.existsSync(path.join(buildDir, 'android'))).to.equal(true);
+	});
+
+	it('resolves without hooks when there is no build directory', async () => {
+		fs.removeSync(buildDir);
+		const cli = createCLI({ 'project-dir': projectDir, platforms: null });
+
+		await run(noopLogger, {}, cli);
+
+		expect(cli.events).to.deep.equal([]);
+	});
+});

--- a/cli/tests/test-command-contract.js
+++ b/cli/tests/test-command-contract.js
@@ -1,0 +1,201 @@
+/*
+ * Titanium SDK
+ * Copyright TiDev, Inc. 04/07/2022-Present
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+import { CLI } from 'titanium/src/cli.js';
+import { expect } from 'chai';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import appc from 'node-appc';
+import * as buildCommand from '../commands/build.js';
+import * as cleanCommand from '../commands/clean.js';
+import * as projectCommand from '../commands/project.js';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Builds a CLI instance that won't print a banner or touch the terminal.
+ *
+ * @returns {CLI}
+ */
+function createCLI() {
+	const cli = new CLI();
+	cli.ready = true;
+	cli.logger.bannerEnabled(false);
+	return cli;
+}
+
+/**
+ * Builds the minimum Commander-ish command object that `executeCommand()` needs.
+ *
+ * @param {Object} module - The command module exposing validate()/run()
+ * @returns {Object}
+ */
+function createCommand(module) {
+	return {
+		name: () => 'test',
+		options: [],
+		opts: () => ({}),
+		conf: { options: {}, flags: {} },
+		module
+	};
+}
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 10));
+
+/**
+ * Runs a command and returns the error it rejected with. Fails if it resolved.
+ *
+ * @param {CLI} cli - The CLI instance
+ * @param {Object} command - The command to execute
+ * @returns {Promise<Error>}
+ */
+async function captureRejection(cli, command) {
+	try {
+		await cli.executeCommand([ undefined, undefined, command ]);
+	} catch (err) {
+		return err;
+	}
+	throw new Error('expected the command to reject, but it resolved');
+}
+
+describe('command completion contract', () => {
+	// The SDK's build/clean/project commands export `async validate()` and rely on
+	// the CLI awaiting the returned Promise before it runs the command. Titanium CLI
+	// 9.0.0 only understood a returned callback-style function, so it would start
+	// run() while validate() was still pending. 9.1.0 added the Promise branch.
+	it('installed Titanium CLI satisfies the commands\' cliVersion', () => {
+		const { version } = JSON.parse(readFileSync(require.resolve('titanium/package.json'), 'utf8'));
+		for (const command of [ buildCommand, cleanCommand, projectCommand ]) {
+			expect(
+				appc.version.satisfies(version, command.cliVersion),
+				`titanium@${version} does not satisfy "${command.cliVersion}"; async validate()/run() will not be awaited`
+			).to.equal(true);
+		}
+	});
+
+	it('awaits an async validate() before starting run()', async () => {
+		const order = [];
+		const cli = createCLI();
+
+		await cli.executeCommand([ undefined, undefined, createCommand({
+			async validate() {
+				order.push('validate:start');
+				await tick();
+				order.push('validate:end');
+			},
+			async run() {
+				order.push('run:start');
+				await tick();
+				order.push('run:end');
+			}
+		}) ]);
+
+		expect(order).to.deep.equal([ 'validate:start', 'validate:end', 'run:start', 'run:end' ]);
+	});
+
+	it('awaits an async run() before emitting cli:post-execute', async () => {
+		const order = [];
+		const cli = createCLI();
+		cli.on('cli:post-execute', () => order.push('post-execute'));
+
+		await cli.executeCommand([ undefined, undefined, createCommand({
+			async run() {
+				order.push('run:start');
+				await tick();
+				order.push('run:end');
+			}
+		}) ]);
+
+		expect(order).to.deep.equal([ 'run:start', 'run:end', 'post-execute' ]);
+	});
+
+	it('aborts the command when async validate() rejects', async () => {
+		let ran = false;
+		const cli = createCLI();
+
+		const err = await captureRejection(cli, createCommand({
+			async validate() {
+				await tick();
+				throw new Error('invalid');
+			},
+			async run() {
+				ran = true;
+			}
+		}));
+
+		expect(err.message).to.equal('invalid');
+		expect(ran).to.equal(false);
+	});
+
+	it('rejects the command when async run() rejects', async () => {
+		const cli = createCLI();
+
+		const err = await captureRejection(cli, createCommand({
+			async run() {
+				await tick();
+				throw new Error('build failed');
+			}
+		}));
+
+		expect(err.message).to.equal('build failed');
+	});
+
+	it('awaits hooks emitted from an async validate()', async () => {
+		const order = [];
+		const cli = createCLI();
+		cli.on('test:hook', {
+			pre(_data, next) {
+				order.push('hook:start');
+				setTimeout(() => {
+					order.push('hook:end');
+					next();
+				}, 10);
+			}
+		});
+
+		await cli.executeCommand([ undefined, undefined, createCommand({
+			async validate(_logger, _config, c) {
+				await c.emit('test:hook');
+				order.push('validate:end');
+			},
+			async run() {
+				order.push('run:start');
+			}
+		}) ]);
+
+		expect(order).to.deep.equal([ 'hook:start', 'hook:end', 'validate:end', 'run:start' ]);
+	});
+});
+
+describe('command exports', () => {
+	for (const [ name, command ] of Object.entries({
+		build: buildCommand,
+		clean: cleanCommand,
+		project: projectCommand
+	})) {
+		it(`${name} exports an async validate()`, () => {
+			expect(command.validate.constructor.name).to.equal('AsyncFunction');
+		});
+
+		// `executeCommand()` resolves immediately for a run() that neither returns a
+		// Promise nor declares a 4th `callback` argument, so the command would report
+		// success while its work is still in flight.
+		it(`${name} run() signals completion to the CLI`, () => {
+			const isAsync = command.run.constructor.name === 'AsyncFunction';
+			const takesCallback = command.run.length >= 4;
+			expect(
+				isAsync || takesCallback,
+				`${name} run() must be async or accept a callback, otherwise the CLI treats it as complete immediately`
+			).to.equal(true);
+		});
+
+		it(`${name} requires a CLI that awaits async validate()`, () => {
+			expect(appc.version.satisfies('9.0.0', command.cliVersion)).to.equal(false);
+			expect(appc.version.satisfies('9.1.0', command.cliVersion)).to.equal(true);
+		});
+	}
+});

--- a/cli/tests/test-load-plugins.js
+++ b/cli/tests/test-load-plugins.js
@@ -1,0 +1,126 @@
+/*
+ * Titanium SDK
+ * Copyright TiDev, Inc. 04/07/2022-Present
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+import { expect } from 'chai';
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import { loadPlugins } from '../lib/load-plugins.js';
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 5));
+
+const noopLogger = {
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+	log() {}
+};
+
+/**
+ * Writes a plugin that `appc.tiplugin.find()` will discover.
+ *
+ * @param {String} pluginsDir - The `plugins` directory to write into
+ * @param {String} id - The plugin id
+ * @param {String} version - The plugin version
+ */
+function writePlugin(pluginsDir, id, version) {
+	const dir = path.join(pluginsDir, id, version);
+	fs.ensureDirSync(path.join(dir, 'hooks'));
+	fs.writeJsonSync(path.join(dir, 'package.json'), { name: id, version });
+}
+
+describe('loadPlugins()', () => {
+	let projectDir;
+	let cli;
+	let config;
+
+	beforeEach(() => {
+		projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ti-plugins-'));
+		fs.ensureDirSync(path.join(projectDir, 'plugins'));
+
+		config = { get: key => (key === 'paths.plugins' ? [] : undefined) };
+
+		cli = {
+			argv: { 'project-dir': projectDir },
+			env: { installPath: projectDir, os: { sdkPaths: [] } },
+			tiapp: { plugins: [] },
+			scanned: [],
+			emitted: [],
+			pending: 0,
+			async scanHooks(dir) {
+				this.pending++;
+				await tick();
+				this.pending--;
+				this.scanned.push(dir);
+			},
+			async emit(name, data) {
+				this.pending++;
+				await tick();
+				this.pending--;
+				this.emitted.push({ name, data });
+			}
+		};
+	});
+
+	afterEach(() => {
+		fs.removeSync(projectDir);
+	});
+
+	it('awaits every plugin hook scan before resolving', async () => {
+		writePlugin(path.join(projectDir, 'plugins'), 'alpha', '1.0.0');
+		writePlugin(path.join(projectDir, 'plugins'), 'beta', '2.0.0');
+		cli.tiapp.plugins = [ { id: 'alpha', version: '1.0.0' }, { id: 'beta', version: '2.0.0' } ];
+
+		await loadPlugins(noopLogger, config, cli);
+
+		expect(cli.pending, 'scans still in flight after loadPlugins() resolved').to.equal(0);
+		expect(cli.scanned).to.have.lengthOf(2);
+		for (const dir of cli.scanned) {
+			expect(path.basename(dir)).to.equal('hooks');
+		}
+	});
+
+	it('awaits the cli:check-plugins event before resolving', async () => {
+		await loadPlugins(noopLogger, config, cli);
+
+		expect(cli.pending, 'emit still in flight after loadPlugins() resolved').to.equal(0);
+		expect(cli.emitted).to.deep.equal([ { name: 'cli:check-plugins', data: { compact: true } } ]);
+	});
+
+	it('honors the silent and compact arguments', async () => {
+		await loadPlugins(noopLogger, config, cli, true, false);
+		expect(cli.emitted).to.deep.equal([]);
+
+		await loadPlugins(noopLogger, config, cli, false, false);
+		expect(cli.emitted).to.deep.equal([ { name: 'cli:check-plugins', data: { compact: false } } ]);
+	});
+
+	it('expands ~ in configured plugin search paths', async function () {
+		if (process.platform === 'win32') {
+			return this.skip();
+		}
+
+		// a `~`-prefixed path only resolves against $HOME via appc.fs.resolvePath();
+		// node's path.resolve() would turn it into "<cwd>/~/..." and silently miss it
+		const name = `.ti-test-plugins-${process.pid}-${Date.now()}`;
+		const homePluginsDir = path.join(os.homedir(), name);
+		writePlugin(homePluginsDir, 'gamma', '3.0.0');
+
+		try {
+			config = { get: key => (key === 'paths.plugins' ? [ `~/${name}` ] : undefined) };
+			cli.tiapp.plugins = [ { id: 'gamma', version: '3.0.0' } ];
+
+			await loadPlugins(noopLogger, config, cli);
+
+			expect(cli.scanned).to.have.lengthOf(1);
+			expect(cli.scanned[0]).to.equal(path.join(homePluginsDir, 'gamma', '3.0.0', 'hooks'));
+		} finally {
+			fs.removeSync(homePluginsDir);
+		}
+	});
+});

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -13,7 +13,7 @@
 
 import appc from 'node-appc';
 import async from 'async';
-import Builder from 'node-titanium-sdk/lib/builder.js';
+import { Builder } from '../../../cli/lib/builder.js';
 import crypto from 'node:crypto';
 import colors from 'colors';
 import { DOMParser } from '@xmldom/xmldom';
@@ -32,7 +32,6 @@ import { injectSPMPackage } from '../lib/ios/spm.js';
 import { hashIconComposerDocument, isIconComposerDocument } from '../lib/icon-composer.js';
 import { exec, spawn } from 'node:child_process';
 import ti from 'node-titanium-sdk';
-import util from 'node:util';
 import xcode from 'xcode';
 import xcodeParser from 'xcode/lib/parser/pbxproj.js';
 import plist from 'simple-plist';
@@ -41,7 +40,7 @@ import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
 const { cyan } = colors;
-const { parallel, series } = appc.async;
+const { parallel } = appc.async;
 const { version } = appc;
 const require = createRequire(import.meta.url);
 const platformsRegExp = new RegExp('^(' + ti.allPlatformNames.join('|') + ')$'); // eslint-disable-line security/detect-non-literal-regexp
@@ -1893,100 +1892,103 @@ class iOSBuilder extends Builder {
 	 *
 	 * @returns {Function} A function to be called async which returns the actual configuration.
 	 */
-	validate(logger, config, cli) {
-		super.validate(logger, config, cli);
+	async validate(logger, config, cli) {
+		await super.validate(logger, config, cli);
 
-		return function (callback) {
-			this.target = cli.argv.target;
-			this.deployType = !/^dist-/.test(this.target) && cli.argv['deploy-type'] ? cli.argv['deploy-type'] : this.deployTypes[this.target];
-			this.buildType = cli.argv['build-type'] || '';
-			this.provisioningProfileUUID = cli.argv['pp-uuid'];
-			if (this.provisioningProfileUUID) {
-				this.provisioningProfile = this.findProvisioningProfile(this.target, this.provisioningProfileUUID);
-			}
+		this.target = cli.argv.target;
+		this.deployType = !/^dist-/.test(this.target) && cli.argv['deploy-type'] ? cli.argv['deploy-type'] : this.deployTypes[this.target];
+		this.buildType = cli.argv['build-type'] || '';
+		this.provisioningProfileUUID = cli.argv['pp-uuid'];
+		if (this.provisioningProfileUUID) {
+			this.provisioningProfile = this.findProvisioningProfile(this.target, this.provisioningProfileUUID);
+		}
 
-			// add the iOS specific default icon to the list of icons
-			this.defaultIcons.unshift(path.join(this.projectDir, 'DefaultIcon-ios.png'));
+		// add the iOS specific default icon to the list of icons
+		this.defaultIcons.unshift(path.join(this.projectDir, 'DefaultIcon-ios.png'));
 
-			// the Icon Composer document that, when present, replaces the generated app icon set.
-			// this is iOS-only -- Android has its own concept of layered icons -- so it is named
-			// after the platform rather than sharing the cross-platform `DefaultIcon.png` name
-			this.defaultIconComposerIcon = path.join(this.projectDir, 'DefaultIcon-ios.icon');
+		// the Icon Composer document that, when present, replaces the generated app icon set.
+		// this is iOS-only -- Android has its own concept of layered icons -- so it is named
+		// after the platform rather than sharing the cross-platform `DefaultIcon.png` name
+		this.defaultIconComposerIcon = path.join(this.projectDir, 'DefaultIcon-ios.icon');
 
-			// manually inject the build profile settings
-			switch (this.deployType) {
-				case 'production':
-					this.showErrorController = false;
-					this.minifyJS = true;
-					this.encryptJS = true;
-					this.minifyCSS = true;
-					this.allowDebugging = false;
-					this.allowProfiling = false;
-					this.includeAllTiModules = false;
-					break;
-
-				case 'test':
-					this.showErrorController = true;
-					this.minifyJS = true;
-					this.encryptJS = true;
-					this.minifyCSS = true;
-					this.allowDebugging = true;
-					this.allowProfiling = true;
-					this.includeAllTiModules = false;
-					break;
-
-				case 'development':
-				default:
-					this.showErrorController = true;
-					this.minifyJS = false;
-					this.encryptJS = false;
-					this.minifyCSS = false;
-					this.allowDebugging = true;
-					this.allowProfiling = true;
-					this.includeAllTiModules = true;
-			}
-
-			if (cli.argv['skip-js-minify']) {
-				this.minifyJS = false;
-			}
-			if (cli.argv['hide-error-controller']) {
+		// manually inject the build profile settings
+		switch (this.deployType) {
+			case 'production':
 				this.showErrorController = false;
-			}
+				this.minifyJS = true;
+				this.encryptJS = true;
+				this.minifyCSS = true;
+				this.allowDebugging = false;
+				this.allowProfiling = false;
+				this.includeAllTiModules = false;
+				break;
 
-			// this may have already been called in an option validate() callback
-			this.initTiappSettings();
+			case 'test':
+				this.showErrorController = true;
+				this.minifyJS = true;
+				this.encryptJS = true;
+				this.minifyCSS = true;
+				this.allowDebugging = true;
+				this.allowProfiling = true;
+				this.includeAllTiModules = false;
+				break;
 
-			// Do we write out process.env into a file in the app to use?
-			this.writeEnvVars = this.deployType !== 'production';
+			case 'development':
+			default:
+				this.showErrorController = true;
+				this.minifyJS = false;
+				this.encryptJS = false;
+				this.minifyCSS = false;
+				this.allowDebugging = true;
+				this.allowProfiling = true;
+				this.includeAllTiModules = true;
+		}
 
-			// Transpilation details
-			this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now
-			// this.minSupportedIosSdk holds the target iOS version to transpile down to
-			// If they're passing flag to do source-mapping, that overrides everything, so turn it on
-			if (cli.argv['source-maps']) {
-				this.sourceMaps = true;
-				// if they haven't, respect the tiapp.xml value if set one way or the other
-			} else if (Object.prototype.hasOwnProperty.call(cli.tiapp, 'source-maps')) { // they've explicitly set a value in tiapp.xml
-				this.sourceMaps = cli.tiapp['source-maps'] === true; // respect the tiapp.xml value
-			} else { // otherwise turn on by default for non-production builds
-				this.sourceMaps = this.deployType !== 'production';
-			}
+		if (cli.argv['skip-js-minify']) {
+			this.minifyJS = false;
+		}
+		if (cli.argv['hide-error-controller']) {
+			this.showErrorController = false;
+		}
 
-			// check for blacklisted files in the Resources directory
-			[	path.join(this.projectDir, 'Resources'),
-				path.join(this.projectDir, 'Resources', 'iphone'),
-				path.join(this.projectDir, 'Resources', 'ios')
-			].forEach(function (dir) {
-				fs.existsSync(dir) && fs.readdirSync(dir).forEach(function (filename) {
-					const lcaseFilename = filename.toLowerCase(),
-						isDir = fs.statSync(path.join(dir, filename)).isDirectory();
+		// this may have already been called in an option validate() callback
+		this.initTiappSettings();
+
+		// Do we write out process.env into a file in the app to use?
+		this.writeEnvVars = this.deployType !== 'production';
+
+		// Transpilation details
+		this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now
+		// this.minSupportedIosSdk holds the target iOS version to transpile down to
+		// If they're passing flag to do source-mapping, that overrides everything, so turn it on
+		if (cli.argv['source-maps']) {
+			this.sourceMaps = true;
+			// if they haven't, respect the tiapp.xml value if set one way or the other
+		} else if (Object.prototype.hasOwnProperty.call(cli.tiapp, 'source-maps')) { // they've explicitly set a value in tiapp.xml
+			this.sourceMaps = cli.tiapp['source-maps'] === true; // respect the tiapp.xml value
+		} else { // otherwise turn on by default for non-production builds
+			this.sourceMaps = this.deployType !== 'production';
+		}
+
+		// check for blacklisted files in the Resources directory
+		const resourceDirectories = [
+			path.join(this.projectDir, 'Resources'),
+			path.join(this.projectDir, 'Resources', 'iphone'),
+			path.join(this.projectDir, 'Resources', 'ios')
+		];
+
+		for (const dir of resourceDirectories) {
+			if (fs.existsSync(dir)) {
+				for (const filename of fs.readdirSync(dir)) {
+					const lcaseFilename = filename.toLowerCase();
+					const isDir = fs.statSync(path.join(dir, filename)).isDirectory();
 
 					// if we have a platform resource dir, then this will not be copied and we should be ok
-					if (ti.allPlatformNames.indexOf(lcaseFilename) !== -1) {
-						return;
+					if (ti.allPlatformNames.includes(lcaseFilename)) {
+						continue;
 					}
 
-					if (this.blacklistDirectories.indexOf(lcaseFilename) !== -1) {
+					if (this.blacklistDirectories.includes(lcaseFilename)) {
 						if (isDir) {
 							logger.error('Found blacklisted directory in the Resources directory.');
 							logger.error(`The directory "${filename}" is a reserved directory.`);
@@ -1997,7 +1999,9 @@ class iOSBuilder extends Builder {
 							logger.error('You must rename this file to something else.\n');
 						}
 						process.exit(1);
-					} else if (this.graylistDirectories.indexOf(lcaseFilename) !== -1) {
+					}
+
+					if (this.graylistDirectories.includes(lcaseFilename)) {
 						if (isDir) {
 							logger.warn('Found graylisted directory in the Resources directory.');
 							logger.warn(`The directory "${filename}" is potentially a reserved directory.`);
@@ -2010,141 +2014,135 @@ class iOSBuilder extends Builder {
 							logger.warn('It is highly recommended you rename this file to something else.');
 						}
 					}
-				}, this);
-			}, this);
-
-			// if in the prepare phase and doing a device/dist build...
-			if (cli.argv.target !== 'simulator' && cli.argv.target !== 'macos') {
-				// make sure they have Apple's WWDR cert installed
-				if (!this.iosInfo.certs.wwdr) {
-					logger.error('WWDR Intermediate Certificate not found\n');
-					logger.log(`Download and install the certificate from ${
-						'https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer'.cyan
-					}\n`);
-					process.exit(1);
-				}
-
-				// validate keychain
-				const keychain = cli.argv.keychain ? appc.fs.resolvePath(cli.argv.keychain) : null;
-				if (keychain && !fs.existsSync(keychain)) {
-					logger.error(`Unable to find keychain "${keychain}"\n`);
-					logger.log('Available keychains:');
-					Object.keys(this.iosInfo.certs.keychains).forEach(function (kc) {
-						logger.log('    ' + kc.cyan);
-					});
-					logger.log();
-					appc.string.suggest(keychain, Object.keys(this.iosInfo.certs.keychains), logger.log);
-					process.exit(1);
 				}
 			}
+		}
 
-			if (cli.argv.target !== 'dist-appstore') {
-				const tool = [];
-				this.allowDebugging && tool.push('debug');
-				this.allowProfiling && tool.push('profiler');
-				tool.forEach(function (type) {
-					if (cli.argv[type + '-host']) {
-						if (typeof cli.argv[type + '-host'] === 'number') {
-							logger.error(`Invalid ${type} host "${cli.argv[type + '-host']}"\n`);
-							logger.log(`The ${type} host must be in the format "host:port".\n`);
-							process.exit(1);
-						}
+		// if in the prepare phase and doing a device/dist build...
+		if (cli.argv.target !== 'simulator' && cli.argv.target !== 'macos') {
+			// make sure they have Apple's WWDR cert installed
+			if (!this.iosInfo.certs.wwdr) {
+				logger.error('WWDR Intermediate Certificate not found\n');
+				logger.log(`Download and install the certificate from ${
+					'https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer'.cyan
+				}\n`);
+				process.exit(1);
+			}
 
-						const parts = cli.argv[type + '-host'].split(':');
-
-						if ((cli.argv.target === 'simulator' && parts.length < 2) || (cli.argv.target !== 'simulator' && parts.length < 4)) {
-							logger.error(`Invalid ${type} host "${cli.argv[type + '-host']}"\n`);
-							if (cli.argv.target === 'simulator') {
-								logger.log(`The ${type} host must be in the format "host:port".\n`);
-							} else {
-								logger.log(`The ${type} host must be in the format "host:port:airkey:hosts".\n`);
-							}
-							process.exit(1);
-						}
-
-						if (parts.length > 1 && parts[1]) {
-							const port = parseInt(parts[1]);
-							if (isNaN(port) || port < 1 || port > 65535) {
-								logger.error(`Invalid ${type} host "${cli.argv[type + '-host']}"\n`);
-								logger.log('The port must be a valid integer between 1 and 65535.\n');
-								process.exit(1);
-							}
-						}
-					}
+			// validate keychain
+			const keychain = cli.argv.keychain ? appc.fs.resolvePath(cli.argv.keychain) : null;
+			if (keychain && !fs.existsSync(keychain)) {
+				logger.error(`Unable to find keychain "${keychain}"\n`);
+				logger.log('Available keychains:');
+				Object.keys(this.iosInfo.certs.keychains).forEach(function (kc) {
+					logger.log('    ' + kc.cyan);
 				});
+				logger.log();
+				appc.string.suggest(keychain, Object.keys(this.iosInfo.certs.keychains), logger.log);
+				process.exit(1);
+			}
+		}
+
+		if (cli.argv.target !== 'dist-appstore') {
+			const tool = [];
+			this.allowDebugging && tool.push('debug');
+			this.allowProfiling && tool.push('profiler');
+			for (const type of tool) {
+				if (cli.argv[`${type}-host`]) {
+					if (typeof cli.argv[`${type}-host`] === 'number') {
+						logger.error(`Invalid ${type} host "${cli.argv[`${type}-host`]}"\n`);
+						logger.log(`The ${type} host must be in the format "host:port".\n`);
+						process.exit(1);
+					}
+
+					const parts = cli.argv[`${type}-host`].split(':');
+
+					if ((cli.argv.target === 'simulator' && parts.length < 2) || (cli.argv.target !== 'simulator' && parts.length < 4)) {
+						logger.error(`Invalid ${type} host "${cli.argv[`${type}-host`]}"\n`);
+						if (cli.argv.target === 'simulator') {
+							logger.log(`The ${type} host must be in the format "host:port".\n`);
+						} else {
+							logger.log(`The ${type} host must be in the format "host:port:airkey:hosts".\n`);
+						}
+						process.exit(1);
+					}
+
+					if (parts.length > 1 && parts[1]) {
+						const port = parseInt(parts[1]);
+						if (isNaN(port) || port < 1 || port > 65535) {
+							logger.error(`Invalid ${type} host "${cli.argv[`${type}-host`]}"\n`);
+							logger.log('The port must be a valid integer between 1 and 65535.\n');
+							process.exit(1);
+						}
+					}
+				}
+			}
+		}
+
+		try {
+			// select iOS version
+			this.iosSdkVersion = cli.argv['ios-version'] || null;
+			this.xcodeEnv = null;
+
+			const xcodeInfo = this.iosInfo.xcode;
+			const sortXcodeIds = (a, b) => {
+				// prioritize selected xcode
+				if (xcodeInfo[a].selected) {
+					return -1;
+				}
+				if (xcodeInfo[b].selected) {
+					return 1;
+				}
+				// newest to oldest
+				return appc.version.gt(xcodeInfo[a].version, xcodeInfo[b].version) ? -1 : appc.version.lt(xcodeInfo[a].version, xcodeInfo[b].version) ? 1 : 0;
+			};
+			const sortedXcodeIds = Object.keys(xcodeInfo).sort(sortXcodeIds);
+
+			if (this.iosSdkVersion) {
+				// find the Xcode for this version
+				for (const ver of sortedXcodeIds) {
+					if (xcodeInfo[ver].sdks.includes(this.iosSdkVersion)) {
+						this.xcodeEnv = xcodeInfo[ver];
+						break;
+					}
+				}
+
+				if (!this.xcodeEnv) {
+					// this should not be possible, but you never know
+					logger.error(`Unable to find any Xcode installations that support iOS SDK ${this.iosSdkVersion}\n`);
+					process.exit(1);
+				}
+
+			} else { // device, simulator, dist-appstore, dist-adhoc
+				const supportedXcodeIds = sortedXcodeIds.filter(id => xcodeInfo[id].supported);
+				selectXcode:
+				for (const id of supportedXcodeIds) {
+					for (const ver of xcodeInfo[id].sdks.sort().reverse()) {
+						if (appc.version.gte(ver, this.minIosVersion)) {
+							this.iosSdkVersion = ver;
+							this.xcodeEnv = xcodeInfo[id];
+							break selectXcode;
+						}
+					}
+				}
+
+				if (!this.iosSdkVersion) {
+					logger.error('Unable to find any Xcode installations with a supported iOS SDK.');
+					logger.error('Please install the latest Xcode and point xcode-select to it.\n');
+					process.exit(1);
+				}
 			}
 
-			series(this, [
-				function selectIosVersion() {
-					this.iosSdkVersion = cli.argv['ios-version'] || null;
-					this.xcodeEnv = null;
+			// select device
+			if (!cli.argv.target.startsWith('dist') && cli.argv.target !== 'macos') {
+				// no --device-id or doing a build-only sim build, so pick a device
 
-					const xcodeInfo = this.iosInfo.xcode;
-
-					function sortXcodeIds(a, b) {
-						// prioritize selected xcode
-						if (xcodeInfo[a].selected) {
-							return -1;
-						}
-						if (xcodeInfo[b].selected) {
-							return 1;
-						}
-						// newest to oldest
-						return appc.version.gt(xcodeInfo[a].version, xcodeInfo[b].version) ? -1 : appc.version.lt(xcodeInfo[a].version, xcodeInfo[b].version) ? 1 : 0;
+				if (cli.argv.target === 'device') {
+					if (!cli.argv['build-only'] && !cli.argv['device-id'] && this.iosInfo.devices.length) {
+						cli.argv['device-id'] = this.iosInfo.devices[0].udid;
 					}
-
-					const sortedXcodeIds = Object.keys(xcodeInfo).sort(sortXcodeIds);
-					if (this.iosSdkVersion) {
-						// find the Xcode for this version
-						sortedXcodeIds.some(function (ver) {
-							if (xcodeInfo[ver].sdks.includes(this.iosSdkVersion)) {
-								this.xcodeEnv = xcodeInfo[ver];
-								return true;
-							}
-							return false;
-						}, this);
-
-						if (!this.xcodeEnv) {
-							// this should not be possible, but you never know
-							logger.error(`Unable to find any Xcode installations that support iOS SDK ${this.iosSdkVersion}\n`);
-							process.exit(1);
-						}
-
-					} else { // device, simulator, dist-appstore, dist-adhoc
-						sortedXcodeIds
-							.filter(id => xcodeInfo[id].supported)
-							.some(function (id) {
-								return xcodeInfo[id].sdks.sort().reverse().some(function (ver) {
-									if (appc.version.gte(ver, this.minIosVersion)) {
-										this.iosSdkVersion = ver;
-										this.xcodeEnv = xcodeInfo[id];
-										return true;
-									}
-									return false;
-								}, this);
-							}, this);
-
-						if (!this.iosSdkVersion) {
-							logger.error('Unable to find any Xcode installations with a supported iOS SDK.');
-							logger.error('Please install the latest Xcode and point xcode-select to it.\n');
-							process.exit(1);
-						}
-					}
-				},
-
-				function selectDevice(next) {
-					if (cli.argv.target.startsWith('dist') || cli.argv.target === 'macos') {
-						return next();
-					}
-
-					// no --device-id or doing a build-only sim build, so pick a device
-
-					if (cli.argv.target === 'device') {
-						if (!cli.argv['build-only'] && !cli.argv['device-id'] && this.iosInfo.devices.length) {
-							cli.argv['device-id'] = this.iosInfo.devices[0].udid;
-						}
-						return next();
-					}
+				} else {
+					// simulator
 
 					// if we found a watch app and --watch-device-id was set, but --launch-watch-app was not, then set it
 					if (this.hasWatchAppV2orNewer && cli.argv['watch-device-id'] && !cli.argv['launch-watch-app-only']) {
@@ -2161,276 +2159,263 @@ class iOSBuilder extends Builder {
 					}
 
 					// target is simulator
-					ioslib.simulator.findSimulators({
-						// env
-						xcodeSelect:            config.get('osx.executables.xcodeSelect'),
-						security:               config.get('osx.executables.security'),
-						// provisioning
-						profileDir:             config.get('ios.profileDir'),
-						// xcode
-						searchPath:             config.get('paths.xcode'),
-						minIosVersion:          this.minIosVersion,
-						supportedVersions:      this.packageJson.vendorDependencies.xcode,
-						// find params
-						appBeingInstalled:      true,
-						simHandleOrUDID:        cli.argv['device-id'],
-						iosVersion:             this.iosSdkVersion,
-						simType:                this.deviceFamily === 'ipad' ? 'ipad' : 'iphone',
-						simVersion:             this.iosSdkVersion,
-						watchAppBeingInstalled: this.hasWatchAppV2orNewer && (cli.argv['launch-watch-app'] || cli.argv['launch-watch-app-only']),
-						watchHandleOrUDID:      cli.argv['watch-device-id'],
-						watchMinOSVersion:      this.watchMinOSVersion,
-						logger: function (msg) {
-							logger.trace(('[ioslib] ' + msg).grey);
-						}
-					}, function (err, simHandle, watchSimHandle, selectedXcode) {
-						if (err) {
-							return next(err);
-						}
-
-						this.simHandle = simHandle;
-						this.watchSimHandle = watchSimHandle;
-						this.xcodeEnv = selectedXcode;
-
-						// only build active arch simulator is 64-bit (iPhone 5s or newer, iPhone 5 and older are not 64-bit)
-						const m = this.simHandle.model.match(/^(iPad|iPhone)([\d]+)/);
-						this.simOnlyActiveArch = !!(m && (m[1] === 'iPad' && parseInt(m[2]) >= 4) || (m[1] === 'iPhone' && parseInt(m[2]) >= 6));
-
-						if (!this.iosSdkVersion) {
-							const sdks = selectedXcode.sdks.sort();
-							this.iosSdkVersion = sdks[sdks.length - 1];
-						}
-
-						next();
-					}.bind(this));
-				},
-
-				function checkEULA() {
-					if (!this.xcodeEnv.eulaAccepted) {
-						logger.error(`Xcode ${
-							this.xcodeEnv.version
-						} end-user license agreement has not been accepted.`);
-						logger.error(`Please launch "${
-							this.xcodeEnv.xcodeapp
-						}" or run "sudo xcodebuild -license" to accept the license.\n`);
-						process.exit(1);
-					}
-				},
-
-				function validateTeamId() {
-					this.teamId = this.tiapp.ios['team-id'];
-					if (!this.teamId && this.provisioningProfile) {
-						if (this.provisioningProfile.team.length === 1) {
-							// only one team, so choose this over the appPrefix
-							this.teamId = this.provisioningProfile.team[0];
-						} else {
-							// we have multiple teams and we don't know which one to pick, so prefer the appPrefix
-							this.teamId = this.provisioningProfile.appPrefix;
-
-							// if the appPrefix is not in the list of teams, then we need to fail and force the user
-							// to manually specify their team id
-							if (this.provisioningProfile.team.length && this.provisioningProfile.team.indexOf(this.teamId) === -1) {
-								logger.log('Available teams:');
-								this.provisioningProfile.team.forEach(function (id) {
-									logger.log('  ' + id.cyan);
-								});
-								logger.log();
-								logger.log('<ti:app xmlns:ti="http://ti.tidev.io">'.grey);
-								logger.log('    <ios>'.grey);
-								logger.log('        <team-id>TEAM ID</team-id>'.magenta);
-								logger.log('    </ios>'.grey);
-								logger.log('</ti:app>'.grey);
-								logger.log();
-								process.exit(1);
+					const { simHandle, watchSimHandle, selectedXcode } = await new Promise((resolve, reject) => {
+						ioslib.simulator.findSimulators({
+							// env
+							xcodeSelect:            config.get('osx.executables.xcodeSelect'),
+							security:               config.get('osx.executables.security'),
+							// provisioning
+							profileDir:             config.get('ios.profileDir'),
+							// xcode
+							searchPath:             config.get('paths.xcode'),
+							minIosVersion:          this.minIosVersion,
+							supportedVersions:      this.packageJson.vendorDependencies.xcode,
+							// find params
+							appBeingInstalled:      true,
+							simHandleOrUDID:        cli.argv['device-id'],
+							iosVersion:             this.iosSdkVersion,
+							simType:                this.deviceFamily === 'ipad' ? 'ipad' : 'iphone',
+							simVersion:             this.iosSdkVersion,
+							watchAppBeingInstalled: this.hasWatchAppV2orNewer && (cli.argv['launch-watch-app'] || cli.argv['launch-watch-app-only']),
+							watchHandleOrUDID:      cli.argv['watch-device-id'],
+							watchMinOSVersion:      this.watchMinOSVersion,
+							logger: function (msg) {
+								logger.trace(('[ioslib] ' + msg).grey);
 							}
-						}
-					}
-				},
-
-				function toSymlinkOrNotToSymlink() {
-					this.symlinkLibrariesOnCopy = config.get('ios.symlinkResources', true) && !cli.argv['force-copy'];
-					this.symlinkFilesOnCopy = false;
-				},
-
-				function determineMinIosVer() {
-					// figure out the min-ios-ver that this app is going to support
-					let defaultMinIosVersion = this.packageJson.minIosVersion;
-
-					this.minIosVer = this.tiapp.ios['min-ios-ver'] || defaultMinIosVersion;
-
-					if (version.lt(this.minIosVer, defaultMinIosVersion)) {
-						logger.warn(`The <min-ios-ver> of the iOS section in the tiapp.xml is lower than the recommended minimum iOS version ${defaultMinIosVersion}`);
-						logger.warn(`Consider bumping the <min-ios-ver> to at least ${defaultMinIosVersion}`);
-						this.minIosVer = defaultMinIosVersion;
-					} else if (version.gt(this.minIosVer, this.iosSdkVersion)) {
-						logger.error(`The <min-ios-ver> of the iOS section in the tiapp.xml is set to ${
-							version.format(this.minIosVer, 2)
-						} and is greater than the specified iOS version ${
-							version.format(this.iosSdkVersion, 2)
-						}`);
-						logger.error(`Either rerun with --ios-version ${
-							version.format(this.minIosVer, 2)
-						} or set the <min-ios-ver> to ${
-							version.format(this.iosSdkVersion, 2)
-						}.\n`);
-						process.exit(1);
-					}
-				},
-
-				function validateDevice() {
-					// check the min-ios-ver for the device we're installing to
-					if (this.target === 'device') {
-						this.getDeviceInfo().devices.forEach(function (device) {
-							if (device.udid !== 'all' && (cli.argv['device-id'] === 'all' || cli.argv['device-id'] === device.udid) && version.lt(device.productVersion, this.minIosVer)) {
-								logger.error(`This app does not support the device "${device.name}"\n`);
-								logger.log(`The device is running iOS ${
-									device.productVersion.cyan
-								}, however the app's the minimum iOS version is set to ${
-									version.format(this.minIosVer, 2, 3).cyan
-								}`);
-								logger.log(`In order to install this app on this device, lower the ${
-									'<min-ios-ver>'.cyan
-								} to ${
-									version.format(device.productVersion, 2, 2).cyan
-								} in the tiapp.xml:`);
-								logger.log();
-								logger.log('<ti:app xmlns:ti="http://ti.tidev.io">'.grey);
-								logger.log('    <ios>'.grey);
-								logger.log(('        <min-ios-ver>' + version.format(device.productVersion, 2, 2) + '</min-ios-ver>').magenta);
-								logger.log('    </ios>'.grey);
-								logger.log('</ti:app>'.grey);
-								logger.log();
-								process.exit(0);
-							}
-						}, this);
-					}
-				},
-
-				function validateModules(next) {
-					this.validateTiModules([ 'ios', 'iphone' ], this.deployType, function (err, modules) {
-						this.modules = modules.found;
-
-						this.commonJsModules = [];
-						this.nativeLibModules = [];
-						this.legacyModules = new Set();
-
-						const nativeHashes = [];
-
-						modules.found.forEach(function (module) {
-							if (module.platform.indexOf('commonjs') !== -1) {
-								module.native = false;
-
-								// look for legacy module.id.js first
-								let libFile = path.join(module.modulePath, module.id + '.js');
-								module.libFile = fs.existsSync(libFile) ? libFile : null;
-								// If no legacy file, let require.resolve get the main script
-								if (!module.libFile) {
-									libFile = require.resolve(module.modulePath);
-									if (fs.existsSync(libFile)) {
-										module.libFile = libFile;
-									}
-
-									if (!module.libFile) {
-										this.logger.error(`Module "${
-											module.id
-										}" (${
-											module.manifest.version || 'latest'
-										}) is missing main file: ${
-											module.id + '.js'
-										}, package.json with "main" entry, index.js, or index.json\n`);
-										process.exit(1);
-									}
-								}
-
-								this.commonJsModules.push(module);
+						}, (err, simHandle, watchSimHandle, selectedXcode) => {
+							if (err) {
+								reject(err);
 							} else {
-								module.native = true;
-								const frameworkName = this.scrubbedModuleId(module.id) + '.framework';
-								const xcFrameworkOfLib = module.id + '.xcframework';
-								const xcFrameworkOfFramework = this.scrubbedModuleId(module.id) + '.xcframework';
-
-								module.isFramework = false;
-
-								// Try to load native module as static library (Obj-C)
-								if (fs.existsSync(path.join(module.modulePath, 'lib' + module.id.toLowerCase() + '.a'))) {
-									module.libName = 'lib' + module.id.toLowerCase() + '.a';
-									module.libFile = path.join(module.modulePath, module.libName);
-									module.isFramework = false;
-
-									// For Obj-C static libraries, use the .a library or hashing
-									this.legacyModules.add(module.id); // Record that this won't support macOS or arm64 sim!
-									nativeHashes.push(module.hash = this.hash(fs.readFileSync(module.libFile)));
-									// Try to load native module as framework (Swift)
-								} else if (fs.existsSync(path.join(module.modulePath, frameworkName))) {
-									module.libName = frameworkName;
-									module.libFile = path.join(module.modulePath, module.libName);
-									module.isFramework = true;
-
-									// For Swift frameworks, use the binary inside the .framework for hashing
-									this.legacyModules.add(module.id); // Record that this won't support macOS or arm64 sim!
-									nativeHashes.push(module.hash = this.hash(fs.readFileSync(path.join(module.libFile, this.scrubbedModuleId(module.id)))));
-								} else if (fs.existsSync(path.join(module.modulePath, xcFrameworkOfLib))) {
-									module.libName = xcFrameworkOfLib;
-									module.libFile = path.join(module.modulePath, module.libName);
-									module.isFramework = true;
-
-									const xcFrameworkInfo = plist.readFileSync(path.join(module.libFile, 'Info.plist'));
-									for (const libInfo of xcFrameworkInfo.AvailableLibraries) {
-										if (libInfo.SupportedPlatformVariant === undefined) {
-											// Device library is used for hash calculation.
-											// TODO: Probably we want to add other varient's library as well.
-											nativeHashes.push(module.hash = this.hash(fs.readFileSync(path.join(module.libFile, libInfo.LibraryIdentifier,  'lib' + module.id.toLowerCase() + '.a'))));
-										} else if (libInfo.SupportedPlatformVariant === 'simulator' && !libInfo.SupportedArchitectures.includes('arm64')) {
-											this.legacyModules.add(module.id);// Record that this won't support arm64 sim!
-										}
-									}
-								} else if (fs.existsSync(path.join(module.modulePath, xcFrameworkOfFramework))) {
-									module.libName = xcFrameworkOfFramework;
-									module.libFile = path.join(module.modulePath, module.libName);
-									module.isFramework = true;
-
-									const xcFrameworkInfo = plist.readFileSync(path.join(module.libFile, 'Info.plist'));
-									const scrubbedModuleId = this.scrubbedModuleId(module.id);
-									for (const libInfo of xcFrameworkInfo.AvailableLibraries) {
-										if (libInfo.SupportedPlatformVariant === undefined) {
-											// Device library is used for hash calculation.
-											// TODO: Probably we want to add other varient's library as well.
-											nativeHashes.push(module.hash = this.hash(fs.readFileSync(path.join(module.libFile, libInfo.LibraryIdentifier, scrubbedModuleId + '.framework', scrubbedModuleId))));
-										} else if (libInfo.SupportedPlatformVariant === 'simulator' && !libInfo.SupportedArchitectures.includes('arm64')) {
-											this.legacyModules.add(module.id);// Record that this won't support arm64 sim!
-										}
-									}
-								} else {
-									this.logger.error(`Module ${
-										module.id.cyan
-									} (${
-										(module.manifest.version || 'latest').cyan
-									}) is missing library or framework file.\n`);
-									this.logger.error('Please validate that your module has been packaged correctly and try it again.');
-									process.exit(1);
-								}
-
-								this.nativeLibModules.push(module);
+								resolve({ simHandle, watchSimHandle, selectedXcode });
 							}
+						});
+					});
 
-							// scan the module for any CLI hooks
-							cli.scanHooks(path.join(module.modulePath, 'hooks'));
-						}, this);
+					this.simHandle = simHandle;
+					this.watchSimHandle = watchSimHandle;
+					this.xcodeEnv = selectedXcode;
 
-						this.modulesNativeHash = this.hash(nativeHashes.length ? nativeHashes.sort().join(',') : '');
-						this.collectModuleSpmDependencies();
+					// only build active arch simulator is 64-bit (iPhone 5s or newer, iPhone 5 and older are not 64-bit)
+					const m = this.simHandle.model.match(/^(iPad|iPhone)([\d]+)/);
+					this.simOnlyActiveArch = !!(m && (m[1] === 'iPad' && parseInt(m[2]) >= 4) || (m[1] === 'iPhone' && parseInt(m[2]) >= 6));
 
-						next();
-					}.bind(this));
+					if (!this.iosSdkVersion) {
+						const sdks = selectedXcode.sdks.sort();
+						this.iosSdkVersion = sdks[sdks.length - 1];
+					}
 				}
-			], function (err) {
-				if (err) {
-					logger.error((err.message || err.toString()) + '\n');
-					process.exit(1);
+			}
+
+			// check EULA
+			if (!this.xcodeEnv.eulaAccepted) {
+				logger.error(`Xcode ${
+					this.xcodeEnv.version
+				} end-user license agreement has not been accepted.`);
+				logger.error(`Please launch "${
+					this.xcodeEnv.xcodeapp
+				}" or run "sudo xcodebuild -license" to accept the license.\n`);
+				process.exit(1);
+			}
+
+			// validate team id
+			this.teamId = this.tiapp.ios['team-id'];
+			if (!this.teamId && this.provisioningProfile) {
+				if (this.provisioningProfile.team.length === 1) {
+					// only one team, so choose this over the appPrefix
+					this.teamId = this.provisioningProfile.team[0];
+				} else {
+					// we have multiple teams and we don't know which one to pick, so prefer the appPrefix
+					this.teamId = this.provisioningProfile.appPrefix;
+
+					// if the appPrefix is not in the list of teams, then we need to fail and force the user
+					// to manually specify their team id
+					if (this.provisioningProfile.team.length && this.provisioningProfile.team.indexOf(this.teamId) === -1) {
+						logger.log('Available teams:');
+						this.provisioningProfile.team.forEach(function (id) {
+							logger.log('  ' + id.cyan);
+						});
+						logger.log();
+						logger.log('<ti:app xmlns:ti="http://ti.tidev.io">'.grey);
+						logger.log('    <ios>'.grey);
+						logger.log('        <team-id>TEAM ID</team-id>'.magenta);
+						logger.log('    </ios>'.grey);
+						logger.log('</ti:app>'.grey);
+						logger.log();
+						process.exit(1);
+					}
 				}
-				callback();
-			});
-		}.bind(this); // end of function returned by validate()
+			}
+
+			// determine if we should symlink resources
+			this.symlinkLibrariesOnCopy = config.get('ios.symlinkResources', true) && !cli.argv['force-copy'];
+			this.symlinkFilesOnCopy = false;
+
+			// figure out the min-ios-ver that this app is going to support
+			let defaultMinIosVersion = this.packageJson.minIosVersion;
+
+			this.minIosVer = this.tiapp.ios['min-ios-ver'] || defaultMinIosVersion;
+
+			if (version.lt(this.minIosVer, defaultMinIosVersion)) {
+				logger.warn(`The <min-ios-ver> of the iOS section in the tiapp.xml is lower than the recommended minimum iOS version ${defaultMinIosVersion}`);
+				logger.warn(`Consider bumping the <min-ios-ver> to at least ${defaultMinIosVersion}`);
+				this.minIosVer = defaultMinIosVersion;
+			} else if (version.gt(this.minIosVer, this.iosSdkVersion)) {
+				logger.error(`The <min-ios-ver> of the iOS section in the tiapp.xml is set to ${
+					version.format(this.minIosVer, 2)
+				} and is greater than the specified iOS version ${
+					version.format(this.iosSdkVersion, 2)
+				}`);
+				logger.error(`Either rerun with --ios-version ${
+					version.format(this.minIosVer, 2)
+				} or set the <min-ios-ver> to ${
+					version.format(this.iosSdkVersion, 2)
+				}.\n`);
+				process.exit(1);
+			}
+
+			// check the min-ios-ver for the device we're installing to
+			if (this.target === 'device') {
+				const { devices } = this.getDeviceInfo();
+				for (const device of devices) {
+					if (device.udid !== 'all' && (cli.argv['device-id'] === 'all' || cli.argv['device-id'] === device.udid) && version.lt(device.productVersion, this.minIosVer)) {
+						logger.error(`This app does not support the device "${device.name}"\n`);
+						logger.log(`The device is running iOS ${
+							device.productVersion.cyan
+						}, however the app's the minimum iOS version is set to ${
+							version.format(this.minIosVer, 2, 3).cyan
+						}`);
+						logger.log(`In order to install this app on this device, lower the ${
+							'<min-ios-ver>'.cyan
+						} to ${
+							version.format(device.productVersion, 2, 2).cyan
+						} in the tiapp.xml:`);
+						logger.log();
+						logger.log('<ti:app xmlns:ti="http://ti.tidev.io">'.grey);
+						logger.log('    <ios>'.grey);
+						logger.log(('        <min-ios-ver>' + version.format(device.productVersion, 2, 2) + '</min-ios-ver>').magenta);
+						logger.log('    </ios>'.grey);
+						logger.log('</ti:app>'.grey);
+						logger.log();
+						process.exit(0);
+					}
+				}
+			}
+
+			// validate modules
+			const modules = await this.validateTiModules([ 'ios', 'iphone' ], this.deployType);
+			this.modules = modules.found;
+			this.commonJsModules = [];
+			this.nativeLibModules = [];
+			this.legacyModules = new Set();
+
+			const nativeHashes = [];
+			for (const module of modules.found) {
+				if (module.platform.includes('commonjs')) {
+					module.native = false;
+
+					// look for legacy module.id.js first
+					let libFile = path.join(module.modulePath, `${module.id}.js`);
+					module.libFile = fs.existsSync(libFile) ? libFile : null;
+					// If no legacy file, let require.resolve get the main script
+					if (!module.libFile) {
+						libFile = require.resolve(module.modulePath);
+						if (fs.existsSync(libFile)) {
+							module.libFile = libFile;
+						}
+
+						if (!module.libFile) {
+							this.logger.error(`Module "${
+								module.id
+							}" (${
+								module.manifest.version || 'latest'
+							}) is missing main file: ${
+								`${module.id}.js`
+							}, package.json with "main" entry, index.js, or index.json\n`);
+							process.exit(1);
+						}
+					}
+
+					this.commonJsModules.push(module);
+				} else {
+					module.native = true;
+					const frameworkName = `${this.scrubbedModuleId(module.id)}.framework`;
+					const xcFrameworkOfLib = `${module.id}.xcframework`;
+					const xcFrameworkOfFramework = `${this.scrubbedModuleId(module.id)}.xcframework`;
+
+					module.isFramework = false;
+
+					// Try to load native module as static library (Obj-C)
+					if (fs.existsSync(path.join(module.modulePath, 'lib' + module.id.toLowerCase() + '.a'))) {
+						module.libName = 'lib' + module.id.toLowerCase() + '.a';
+						module.libFile = path.join(module.modulePath, module.libName);
+						module.isFramework = false;
+
+						// For Obj-C static libraries, use the .a library or hashing
+						this.legacyModules.add(module.id); // Record that this won't support macOS or arm64 sim!
+						nativeHashes.push(module.hash = this.hash(fs.readFileSync(module.libFile)));
+						// Try to load native module as framework (Swift)
+					} else if (fs.existsSync(path.join(module.modulePath, frameworkName))) {
+						module.libName = frameworkName;
+						module.libFile = path.join(module.modulePath, module.libName);
+						module.isFramework = true;
+
+						// For Swift frameworks, use the binary inside the .framework for hashing
+						this.legacyModules.add(module.id); // Record that this won't support macOS or arm64 sim!
+						nativeHashes.push(module.hash = this.hash(fs.readFileSync(path.join(module.libFile, this.scrubbedModuleId(module.id)))));
+					} else if (fs.existsSync(path.join(module.modulePath, xcFrameworkOfLib))) {
+						module.libName = xcFrameworkOfLib;
+						module.libFile = path.join(module.modulePath, module.libName);
+						module.isFramework = true;
+
+						const xcFrameworkInfo = plist.readFileSync(path.join(module.libFile, 'Info.plist'));
+						for (const libInfo of xcFrameworkInfo.AvailableLibraries) {
+							if (libInfo.SupportedPlatformVariant === undefined) {
+								// Device library is used for hash calculation.
+								// TODO: Probably we want to add other varient's library as well.
+								nativeHashes.push(module.hash = this.hash(fs.readFileSync(path.join(module.libFile, libInfo.LibraryIdentifier,  'lib' + module.id.toLowerCase() + '.a'))));
+							} else if (libInfo.SupportedPlatformVariant === 'simulator' && !libInfo.SupportedArchitectures.includes('arm64')) {
+								this.legacyModules.add(module.id);// Record that this won't support arm64 sim!
+							}
+						}
+					} else if (fs.existsSync(path.join(module.modulePath, xcFrameworkOfFramework))) {
+						module.libName = xcFrameworkOfFramework;
+						module.libFile = path.join(module.modulePath, module.libName);
+						module.isFramework = true;
+
+						const xcFrameworkInfo = plist.readFileSync(path.join(module.libFile, 'Info.plist'));
+						const scrubbedModuleId = this.scrubbedModuleId(module.id);
+						for (const libInfo of xcFrameworkInfo.AvailableLibraries) {
+							if (libInfo.SupportedPlatformVariant === undefined) {
+								// Device library is used for hash calculation.
+								// TODO: Probably we want to add other varient's library as well.
+								nativeHashes.push(module.hash = this.hash(fs.readFileSync(path.join(module.libFile, libInfo.LibraryIdentifier, scrubbedModuleId + '.framework', scrubbedModuleId))));
+							} else if (libInfo.SupportedPlatformVariant === 'simulator' && !libInfo.SupportedArchitectures.includes('arm64')) {
+								this.legacyModules.add(module.id);// Record that this won't support arm64 sim!
+							}
+						}
+					} else {
+						this.logger.error(`Module ${
+							module.id.cyan
+						} (${
+							(module.manifest.version || 'latest').cyan
+						}) is missing library or framework file.\n`);
+						this.logger.error('Please validate that your module has been packaged correctly and try it again.');
+						process.exit(1);
+					}
+
+					this.nativeLibModules.push(module);
+				}
+
+				// scan the module for any CLI hooks
+				await cli.scanHooks(path.join(module.modulePath, 'hooks'));
+			}
+
+			this.modulesNativeHash = this.hash(nativeHashes.length ? nativeHashes.sort().join(',') : '');
+			this.collectModuleSpmDependencies();
+		} catch (err) {
+			logger.error((err.message || err.toString()) + '\n');
+			process.exit(1);
+		}
 	}
 
 	scrubbedModuleId(moduleId) {
@@ -2661,9 +2646,9 @@ class iOSBuilder extends Builder {
 	 * @param {Object} cli - The Titanium CLI instance.
 	 * @param {Function} finished - A function to call when the build has finished or errored.
 	 */
-	async run(logger, config, cli, finished) {
+	async run(logger, config, cli) {
 		try {
-			super.run(logger, config, cli);
+			await super.run(logger, config, cli);
 
 			// force the platform to "ios" just in case it was "iphone" so that plugins can reference it
 			cli.argv.platform = 'ios';
@@ -2808,11 +2793,6 @@ class iOSBuilder extends Builder {
 				this.logger.error('Build failed. Reason: Unknown');
 			}
 			process.exit(1);
-		}
-
-		// We're done. Invoke optional callback if provided.
-		if (finished) {
-			finished();
 		}
 	}
 
@@ -6334,9 +6314,6 @@ class iOSBuilder extends Builder {
 			};
 		}
 
-		// shared by the Icon Composer path and the app icon set path below
-		const boundGenerateAppIcons = util.promisify(this.generateAppIcons).bind(this);
-
 		// the Icon Composer document already covers every app icon size and appearance, so the
 		// only images left to produce are the launch logos
 		if (iconComposerIcon) {
@@ -6370,7 +6347,7 @@ class iOSBuilder extends Builder {
 				return;
 			}
 
-			return boundGenerateAppIcons(missingLaunchLogos);
+			return this.generateAppIcons(missingLaunchLogos);
 		}
 
 		// The original list of icons we may need (we trim this down as we match them)
@@ -6569,14 +6546,14 @@ class iOSBuilder extends Builder {
 
 		if (!defaultIcon) {
 			// we're going to fail, but we let generateAppIcons() do the dirty work
-			return boundGenerateAppIcons(missingIcons);
+			return this.generateAppIcons(missingIcons);
 		}
 
 		if (!defaultIconChanged) {
 			// we have missing icons, but the default icon hasn't changed
 			// call generateAppIcons() and have it deal with determining if the icons need
 			// to be generated or if it needs to error out
-			return boundGenerateAppIcons(missingIcons);
+			return this.generateAppIcons(missingIcons);
 		}
 
 		if (!this.forceRebuild) {
@@ -6586,7 +6563,7 @@ class iOSBuilder extends Builder {
 			this.forceRebuild = true;
 		}
 
-		return boundGenerateAppIcons(missingIcons);
+		return this.generateAppIcons(missingIcons);
 	}
 
 	/**

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -16,7 +16,7 @@ import appc from 'node-appc';
 import fs from 'fs-extra';
 import archiver from 'archiver';
 import async from 'async';
-import Builder from 'node-titanium-sdk/lib/builder.js';
+import { Builder } from '../../../cli/lib/builder.js';
 import ioslib from 'ioslib';
 import jsanalyze from 'node-titanium-sdk/lib/jsanalyze.js';
 import ejs from 'ejs';
@@ -32,7 +32,6 @@ import { loadPackageJson } from '../../../cli/lib/pkginfo.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const iosPackageJson = loadPackageJson(__dirname);
-const { series } = appc.async;
 const parsePlist = util.promisify(plist.readFile);
 const SPM_METADATA_VERSION = 1;
 
@@ -43,19 +42,20 @@ export class iOSModuleBuilder extends Builder {
 		});
 	}
 
-	validate(logger, config, cli) {
+	async validate(logger, config, cli) {
 		super.config(logger, config, cli);
-		super.validate(logger, config, cli);
+		await super.validate(logger, config, cli);
 
-		// cli.manifest is set by the --project-dir option's callback in cli/commands/build.js
-		this.manifest      = cli.manifest;
-		this.moduleId      = cli.manifest.moduleid;
-		this.moduleName    = cli.manifest.name;
+		// cli.manifest is the module's "manifest" file, loaded by the --project-dir
+		// option's callback in cli/commands/build.js
+		this.manifest             = cli.manifest;
+		this.moduleId             = this.manifest.moduleid;
+		this.moduleName           = this.manifest.name;
 		this.moduleIdAsIdentifier = this.scrubbedName(this.moduleId);
-		this.moduleVersion = cli.manifest.version;
-		this.isMacOSEnabled  = this.detectMacOSTarget();
-		this.moduleGuid    = cli.manifest.guid;
-		this.isFramework   = fs.existsSync(path.join(this.projectDir, 'Info.plist')); // TODO: There MUST be a better way to determine if it's a framework (Swift)
+		this.moduleVersion        = this.manifest.version;
+		this.isMacOSEnabled       = this.detectMacOSTarget();
+		this.moduleGuid           = this.manifest.guid;
+		this.isFramework          = fs.existsSync(path.join(this.projectDir, 'Info.plist')); // TODO: There MUST be a better way to determine if it's a framework (Swift)
 
 		this.buildOnly     = cli.argv['build-only'];
 		this.xcodeEnv      = null;
@@ -70,30 +70,23 @@ export class iOSModuleBuilder extends Builder {
 			process.exit(1);
 		}
 
-		return function (finished) {
-			ioslib.detect({
-				// env
-				xcodeSelect:       config.get('osx.executables.xcodeSelect'),
-				security:          config.get('osx.executables.security'),
-				// provisioning
-				profileDir:        config.get('ios.profileDir'),
-				// xcode
-				searchPath:        config.get('paths.xcode'),
-				minIosVersion:     iosPackageJson.minIosVersion,
-				supportedVersions: iosPackageJson.vendorDependencies.xcode
-			}, function (err, iosInfo) {
-				this.iosInfo = iosInfo;
-				this.xcodeEnv = this.iosInfo.selectedXcode;
-
-				if (!this.xcodeEnv) {
-					// this should never happen
-					logger.error('Unable to find suitable Xcode install\n');
-					process.exit(1);
-				}
-
-				finished();
-			}.bind(this));
-		}.bind(this);
+		this.iosInfo = await util.promisify(ioslib.detect)({
+			// env
+			xcodeSelect:       config.get('osx.executables.xcodeSelect'),
+			security:          config.get('osx.executables.security'),
+			// provisioning
+			profileDir:        config.get('ios.profileDir'),
+			// xcode
+			searchPath:        config.get('paths.xcode'),
+			minIosVersion:     iosPackageJson.minIosVersion,
+			supportedVersions: iosPackageJson.vendorDependencies.xcode
+		});
+		this.xcodeEnv = this.iosInfo.selectedXcode;
+		if (!this.xcodeEnv) {
+			// this should never happen
+			logger.error('Unable to find suitable Xcode install\n');
+			process.exit(1);
+		}
 	}
 
 	detectMacOSTarget() {
@@ -233,43 +226,25 @@ export class iOSModuleBuilder extends Builder {
 		}
 	}
 
-	run(logger, config, cli, finished) {
-		super.run(logger, config, cli);
-
-		series(this, [
-			function (next) {
-				cli.emit('build.module.pre.construct', this, next);
-			},
-
-			'initialize',
-			'loginfo',
-
-			function (next) {
-				cli.emit('build.module.pre.compile', this, next);
-			},
-
-			'processLicense',
-			'processTiXcconfig',
-			'compileJS',
-			'buildModule',
-			'createUniversalBinary',
-			function (next) {
-				// eslint-disable-next-line promise/no-callback-in-promise
-				this.verifyBuildArch().then(next).catch(next);
-			},
-			'packageModule',
-			function (next) {
-				this.runModule(cli, next);
-			},
-
-			function (next) {
-				cli.emit('build.module.post.compile', this, next);
-			}
-		], function (err) {
-			cli.emit('build.module.finalize', this, function () {
-				finished(err);
-			});
-		});
+	async run(logger, config, cli) {
+		try {
+			await super.run(logger, config, cli);
+			await cli.emit('build.module.pre.construct', this);
+			this.initialize();
+			this.loginfo();
+			await cli.emit('build.module.pre.compile', this);
+			this.processLicense();
+			this.processTiXcconfig();
+			await this.compileJS();
+			await this.buildModule();
+			await this.createUniversalBinary();
+			await this.verifyBuildArch();
+			await this.packageModule();
+			await this.runModule(cli);
+			await cli.emit('build.module.post.compile', this);
+		} finally {
+			await cli.emit('build.module.finalize', this);
+		}
 	}
 
 	initialize() {
@@ -447,7 +422,7 @@ export class iOSModuleBuilder extends Builder {
 		}
 	}
 
-	processTiXcconfig(next) {
+	processTiXcconfig() {
 		const srcFile = path.join(this.projectDir, this.moduleName + '.xcodeproj', 'project.pbxproj');
 		const xcodeProject = xcode.project(path.join(this.projectDir, this.moduleName + '.xcodeproj', 'project.pbxproj'));
 		const contents = fs.readFileSync(srcFile).toString();
@@ -539,11 +514,9 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 				}
 			}, this);
 		}
-
-		next();
 	}
 
-	compileJS(next) {
+	async compileJS() {
 		this.jsFilesToEncrypt = [];
 
 		const moduleJS = this.moduleId + '.js',
@@ -618,113 +591,113 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 				);
 			});
 
-		const tasks = [
-			// 1. compile module js
-			function (cb) {
-				fs.existsSync(jsFile) && this.jsFilesToEncrypt.push(jsFile);
+		// 1. compile module js
+		if (fs.existsSync(jsFile)) {
+			this.jsFilesToEncrypt.push(jsFile);
+		}
 
-				if (!this.jsFilesToEncrypt.length) {
-					renderData.mainEncryptedAsset = '';
-					renderData.mainEncryptedAssetReturn = 'return nil;';
-					return cb();
-				}
+		if (!this.jsFilesToEncrypt.length) {
+			renderData.mainEncryptedAsset = '';
+			renderData.mainEncryptedAssetReturn = 'return nil;';
+		} else {
+			fs.ensureDirSync(this.assetsDir);
 
-				fs.ensureDirSync(this.assetsDir);
-
+			await new Promise((resolve, reject) => {
 				titaniumPrepHook(
 					path.join(this.platformPath, 'titanium_prep'),
 					[ this.moduleId, this.assetsDir, this.moduleGuid ],
 					{ jsFiles: this.jsFilesToEncrypt, placeHolder: 'mainEncryptedAsset' },
-					cb
-				);
-			},
-
-			// 2. compile all other JS files in assets dir
-			function (cb) {
-				try {
-					if (!fs.existsSync(this.assetsDir)) {
-						throw new Error();
-					}
-
-					this.dirWalker(this.assetsDir, function (file) {
-						if (path.extname(file) === '.js' && this.jsFilesToEncrypt.indexOf(file) === -1) {
-							this.jsFilesToEncrypt.push(file);
+					(err, result) => {
+						if (err) {
+							reject(err);
+						} else {
+							resolve(result);
 						}
-					}.bind(this));
-
-					const jsFilesCount = this.jsFilesToEncrypt.length;
-
-					if (jsFilesCount === 0 || (fs.existsSync(jsFile) && jsFilesCount === 1)) {
-						throw new Error();
 					}
+				);
+			});
+		}
 
-					titaniumPrepHook(
-						path.join(this.platformPath, 'titanium_prep'),
-						[ this.moduleId, this.assetsDir, this.moduleGuid ],
-						{ jsFiles: this.jsFilesToEncrypt, placeHolder: 'allEncryptedAssets' },
-						cb
-					);
-				} catch (e) {
-					renderData.allEncryptedAssets = renderData.mainEncryptedAsset;
-					renderData.allEncryptedAssetsReturn = 'return nil;';
-					cb();
+		// 2. compile all other JS files in assets dir
+		let hasAdditionalAssets = false;
+		try {
+			this.dirWalker(this.assetsDir, (file) => {
+				if (path.extname(file) === '.js' && this.jsFilesToEncrypt.indexOf(file) === -1) {
+					this.jsFilesToEncrypt.push(file);
 				}
-			},
+			});
 
-			// 3. write encrypted data to template
-			function (cb) {
-				const data = ejs.render(fs.readFileSync(this.assetsTemplateFile).toString(), renderData),
-					moduleAssetsDir = path.join(this.projectDir, 'Classes'),
-					moduleAssetsFile = path.join(moduleAssetsDir, this.moduleIdAsIdentifier + 'ModuleAssets.m');
+			const jsFilesCount = this.jsFilesToEncrypt.length;
+			hasAdditionalAssets = jsFilesCount > 0 && !(fs.existsSync(jsFile) && jsFilesCount === 1);
+		} catch {
+			// the assets dir doesn't exist or couldn't be read, so there's nothing more to encrypt
+		}
 
-				this.logger.debug(`Writing module assets file: ${moduleAssetsFile.cyan}`);
-				fs.ensureDirSync(moduleAssetsDir);
-				fs.writeFileSync(moduleAssetsFile, data);
-				cb();
-			},
+		if (hasAdditionalAssets) {
+			await new Promise((resolve, reject) => {
+				titaniumPrepHook(
+					path.join(this.platformPath, 'titanium_prep'),
+					[ this.moduleId, this.assetsDir, this.moduleGuid ],
+					{ jsFiles: this.jsFilesToEncrypt, placeHolder: 'allEncryptedAssets' },
+					(err, result) => {
+						if (err) {
+							reject(err);
+						} else {
+							resolve(result);
+						}
+					}
+				);
+			});
+		} else {
+			renderData.allEncryptedAssets = renderData.mainEncryptedAsset;
+			renderData.allEncryptedAssetsReturn = 'return nil;';
+		}
 
-			// 4. generate exports
-			function (cb) {
-				this.jsFilesToEncrypt.forEach(function (file) {
-					const r = jsanalyze.analyzeJsFile(file, { minify: true });
-					this.tiSymbols[file] = r.symbols;
-					this.metaData.push.apply(this.metaData, r.symbols);
-				}.bind(this));
+		// 3. write encrypted data to template
+		const data = ejs.render(fs.readFileSync(this.assetsTemplateFile).toString(), renderData);
+		const moduleAssetsDir = path.join(this.projectDir, 'Classes');
+		const moduleAssetsFile = path.join(moduleAssetsDir, this.moduleIdAsIdentifier + 'ModuleAssets.m');
+		this.logger.debug(`Writing module assets file: ${moduleAssetsFile.cyan}`);
+		fs.ensureDirSync(moduleAssetsDir);
+		fs.writeFileSync(moduleAssetsFile, data);
 
-				fs.existsSync(this.metaDataFile) && fs.unlinkSync(this.metaDataFile);
-				const metadata = { exports: this.metaData };
-				this.spmMetadata = this.getSpmMetadata();
-				if (this.spmMetadata) {
-					metadata.spm = this.spmMetadata;
-				}
-				fs.writeFileSync(this.metaDataFile, JSON.stringify(metadata));
+		// 4. generate exports
+		for (const file of this.jsFilesToEncrypt) {
+			const r = jsanalyze.analyzeJsFile(file, { minify: true });
+			this.tiSymbols[file] = r.symbols;
+			this.metaData.push.apply(this.metaData, r.symbols);
+		}
 
-				cb();
-			}
-		];
-
-		appc.async.series(this, tasks, next);
+		if (fs.existsSync(this.metaDataFile)) {
+			fs.unlinkSync(this.metaDataFile);
+		}
+		const metadata = { exports: this.metaData };
+		this.spmMetadata = this.getSpmMetadata();
+		if (this.spmMetadata) {
+			metadata.spm = this.spmMetadata;
+		}
+		fs.writeFileSync(this.metaDataFile, JSON.stringify(metadata));
 	}
 
-	buildModule(next) {
+	async buildModule() {
 		const opts = {
 			cwd: this.projectDir,
 			env: {}
 		};
-		Object.keys(process.env).forEach(function (key) {
+		for (const key of Object.keys(process.env)) {
 			opts.env[key] = process.env[key];
-		});
+		}
 		opts.env.DEVELOPER_DIR = this.xcodeEnv.path;
 
 		const xcodebuildHook = this.cli.createHook('build.module.ios.xcodebuild', this, function (exe, args, opts, type, done) {
-			this.logger.debug(`Running: ${('DEVELOPER_DIR=' + opts.env.DEVELOPER_DIR + ' ' + exe + ' ' + args.join(' ')).cyan}`);
+			this.logger.debug(`Running: ${`DEVELOPER_DIR=${opts.env.DEVELOPER_DIR} ${exe} ${args.join(' ')}`.cyan}`);
 			const p = spawn(exe, args, opts),
 				out = [],
 				err = [];
 			let stopOutputting = false;
 
-			p.stdout.on('data', function (data) {
-				data.toString().split('\n').forEach(function (line) {
+			p.stdout.on('data', (data) => {
+				for (const line of data.toString().split('\n')) {
 					if (line.length) {
 						out.push(line);
 						if (line.indexOf('Failed to minify') !== -1) {
@@ -734,23 +707,23 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 							this.logger.trace('[' + type + '] ' + line);
 						}
 					}
-				}, this);
-			}.bind(this));
+				}
+			});
 
-			p.stderr.on('data', function (data) {
-				data.toString().split('\n').forEach(function (line) {
+			p.stderr.on('data', (data) => {
+				for (const line of data.toString().split('\n')) {
 					if (line.length) {
 						err.push(line);
 					}
-				}, this);
-			}.bind(this));
+				}
+			});
 
-			p.on('close', function (code) {
+			p.on('close', (code) => {
 				if (code) {
 					// just print the entire error buffer
-					err.forEach(function (line) {
-						this.logger.error('[' + type + '] ' + line);
-					}, this);
+					for (const line of err) {
+						this.logger.error(`[${type}] ${line}`);
+					}
 					this.logger.log();
 					if (type === 'xcode-macos') {
 						this.logger.info('To exclude mac target, set/add mac: false in manifest file.');
@@ -759,13 +732,13 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 				}
 
 				// end of the line
-				done(code);
-			}.bind(this));
-		}.bind(this));
+				done();
+			});
+		});
 
 		const xcBuild = this.xcodeEnv.executables.xcodebuild;
 
-		const xcodeBuildArgumentsForTarget = function (target) {
+		const xcodeBuildArgumentsForTarget = (target) => {
 			let args = [
 				'archive',
 				'-configuration', 'Release',
@@ -824,39 +797,55 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 			}
 
 			return args;
-		}.bind(this);
+		};
 
-		this.cli.env.getOSInfo(osInfo => {
-			const macOsVersion = osInfo.osver;
+		const osInfo = await this.cli.env.getOSInfo();
+		const macOsVersion = osInfo.osver;
 
-			// 1. Create a build for the simulator
-			xcodebuildHook(xcBuild, xcodeBuildArgumentsForTarget('iphonesimulator'), opts, 'xcode-sim', () => {
-				// 2. Create a build for device
-				xcodebuildHook(xcBuild, xcodeBuildArgumentsForTarget('iphoneos'), opts, 'xcode-dist', () => {
-					const osVersionParts = macOsVersion.split('.').map(n => parseInt(n));
-					if (osVersionParts[0] > 10 || (osVersionParts[0] === 10 && osVersionParts[1] >= 15)) {
-						// 3. Create a build for the mac-catalyst if enabled
-						if (this.isMacOSEnabled) {
-							this.ensureTitaniumKitCatalystSymlinks();
-							xcodebuildHook(xcBuild, xcodeBuildArgumentsForTarget('macosx'), opts, 'xcode-macos', next);
-						} else {
-							this.logger.info('macOS support disabled in Xcode project. Skipping …');
-							next();
-						}
+		// 1. Create a build for the simulator
+		await new Promise((resolve, reject) => xcodebuildHook(xcBuild, xcodeBuildArgumentsForTarget('iphonesimulator'), opts, 'xcode-sim', (err, result) => {
+			if (err) {
+				reject(err);
+			} else {
+				resolve(result);
+			}
+		}));
+
+		// 2. Create a build for device
+		await new Promise((resolve, reject) => xcodebuildHook(xcBuild, xcodeBuildArgumentsForTarget('iphoneos'), opts, 'xcode-dist', (err, result) => {
+			if (err) {
+				reject(err);
+			} else {
+				resolve(result);
+			}
+		}));
+
+		const osVersionParts = macOsVersion.split('.').map(n => parseInt(n));
+		if (osVersionParts[0] > 10 || (osVersionParts[0] === 10 && osVersionParts[1] >= 15)) {
+			// 3. Create a build for the mac-catalyst if enabled
+			if (this.isMacOSEnabled) {
+				this.ensureTitaniumKitCatalystSymlinks();
+				this.logger.info('Creating build for mac-catalyst');
+				await new Promise((resolve, reject) => xcodebuildHook(xcBuild, xcodeBuildArgumentsForTarget('macosx'), opts, 'xcode-macos', (err, result) => {
+					if (err) {
+						reject(err);
 					} else {
-						this.logger.warn('Ignoring build for mac as mac target is < 10.15');
-						next();
+						resolve(result);
 					}
-				});
-			});
-		});
+				}));
+			} else {
+				this.logger.info('macOS support disabled in Xcode project. Skipping …');
+			}
+		} else {
+			this.logger.warn('Ignoring build for mac as mac target is < 10.15');
+		}
 	}
 
-	createUniversalBinary(next) {
+	async createUniversalBinary() {
 		this.logger.info('Creating universal framework/library');
 
 		const moduleId = this.isFramework ? this.moduleIdAsIdentifier : this.moduleId;
-		const findLib = function (dest) {
+		const findLib = (dest) => {
 			let libPath = this.isFramework ? `.xcarchive/Products/Library/Frameworks/${moduleId}.framework` : `.xcarchive/Products/usr/local/lib/lib${moduleId}.a`;
 			const lib = path.join(this.projectDir, 'build', dest + libPath);
 			this.logger.info(`Looking for ${lib}`);
@@ -875,9 +864,10 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 				}
 			}
 			return lib;
-		}.bind(this);
+		};
+
 		// Find the debug symbols (dSYM) for the generated framework
-		const findDSYM = function (dest) {
+		const findDSYM = (dest) => {
 			const dSymPath = `.xcarchive/dSYMs/${moduleId}.framework.dSYM`;
 			const dSym = path.join(this.projectDir, 'build', dest + dSymPath);
 			this.logger.debug(`Looking for dSYM ${dSym}`);
@@ -887,7 +877,7 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 				return null;
 			}
 			return dSym;
-		}.bind(this);
+		};
 
 		// Create xcframework
 		const args = [];
@@ -900,7 +890,7 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 
 		let lib = findLib('iphoneos');
 		if (lib instanceof Error) {
-			return next(lib);
+			throw lib;
 		}
 		args.push('-create-xcframework');
 		args.push(buildType, lib);
@@ -914,7 +904,7 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 
 		lib = findLib('iphonesimulator');
 		if (lib instanceof Error) {
-			return next(lib);
+			throw lib;
 		}
 		args.push(buildType, lib);
 		if (!this.isFramework) {
@@ -953,23 +943,25 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 		);
 
 		this.logger.debug(`Running: ${(this.xcodeEnv.executables.xcodebuild + ' ' + args.join(' ')).cyan}`);
-		appc.subprocess.run(this.xcodeEnv.executables.xcodebuild, args, function (code, out, err) {
-			if (code) {
-				this.logger.error(`Failed to generate universal binary (code ${code}):`);
-				this.logger.error(err.trim() + '\n');
-				process.exit(1);
-			}
-
-			// Ensure that each Headers directory contains a file to keep it around in source control
-			for (const dir of fs.readdirSync(xcframeworkDest)) {
-				const headersPath = path.join(xcframeworkDest, dir, 'Headers');
-
-				if (fs.existsSync(headersPath) && fs.readdirSync(headerPath).length === 0) {
-					fs.writeFileSync(path.join(headersPath, `.${moduleId}-keep`), 'This file is to ensure the Headers directory gets checked into source control');
+		await new Promise((resolve) => {
+			appc.subprocess.run(this.xcodeEnv.executables.xcodebuild, args, (code, _out, err) => {
+				if (code) {
+					this.logger.error(`Failed to generate universal binary (code ${code}):`);
+					this.logger.error(err.trim() + '\n');
+					process.exit(1);
 				}
+				resolve();
+			});
+		});
+
+		// Ensure that each Headers directory contains a file to keep it around in source control
+		for (const dir of fs.readdirSync(xcframeworkDest)) {
+			const headersPath = path.join(xcframeworkDest, dir, 'Headers');
+
+			if (fs.existsSync(headersPath) && fs.readdirSync(headerPath).length === 0) {
+				fs.writeFileSync(path.join(headersPath, `.${moduleId}-keep`), 'This file is to ensure the Headers directory gets checked into source control');
 			}
-			next();
-		}.bind(this));
+		}
 	}
 
 	async verifyBuildArch() {
@@ -1057,165 +1049,167 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 		}
 	}
 
-	packageModule(next) {
-		const dest = archiver('zip', {
+	async packageModule() {
+		return new Promise((resolve) => {
+			const dest = archiver('zip', {
 				forceUTC: true
-			}),
-			origConsoleError = console.error,
-			moduleId = this.moduleId,
-			version = this.moduleVersion,
-			moduleZipName = [ moduleId, '-iphone-', version, '.zip' ].join(''),
-			moduleZipFullPath = path.join(this.distDir, moduleZipName),
-			moduleFolders = path.join('modules', 'iphone', moduleId, version),
-			binarylibName = this.isFramework ? this.moduleIdAsIdentifier + '.xcframework' : moduleId + '.xcframework',
-			binarylibFile = path.join(this.projectDir, 'build', binarylibName);
-
-		this.logger.info(`Binary framework/library file: ${binarylibFile}`);
-
-		this.moduleZipPath = moduleZipFullPath;
-
-		// since the archiver library didn't set max listeners, we squelch all error output
-		console.error = function () {};
-
-		try {
-			// if the zip file is there, remove it
-			fs.ensureDirSync(this.distDir);
-			fs.existsSync(moduleZipFullPath) && fs.unlinkSync(moduleZipFullPath);
-			const zipStream = fs.createWriteStream(moduleZipFullPath);
-			zipStream.on('close', function () {
-				console.error = origConsoleError;
-				next();
 			});
-			dest.catchEarlyExitAttached = true; // silence exceptions
-			dest.pipe(zipStream);
+			const origConsoleError = console.error;
+			const moduleId = this.moduleId;
+			const version = this.moduleVersion;
+			const moduleZipName = [ moduleId, '-iphone-', version, '.zip' ].join('');
+			const moduleZipFullPath = path.join(this.distDir, moduleZipName);
+			const moduleFolders = path.join('modules', 'iphone', moduleId, version);
+			const binarylibName = this.isFramework ? this.moduleIdAsIdentifier + '.xcframework' : moduleId + '.xcframework';
+			const binarylibFile = path.join(this.projectDir, 'build', binarylibName);
 
-			this.logger.info('Creating module zip');
+			this.logger.info(`Binary framework/library file: ${binarylibFile}`);
 
-			// 1. documentation folder
-			const mdRegExp = /\.md$/;
-			if (fs.existsSync(this.documentationDir)) {
-				(function walk(dir, parent) {
-					if (!fs.existsSync(dir)) {
-						return;
-					}
+			this.moduleZipPath = moduleZipFullPath;
 
-					fs.readdirSync(dir).forEach(function (name) {
-						const file = path.join(dir, name);
-						if (!fs.existsSync(file)) {
+			// since the archiver library didn't set max listeners, we squelch all error output
+			console.error = function () {};
+
+			try {
+				// if the zip file is there, remove it
+				fs.ensureDirSync(this.distDir);
+				fs.existsSync(moduleZipFullPath) && fs.unlinkSync(moduleZipFullPath);
+				const zipStream = fs.createWriteStream(moduleZipFullPath);
+				zipStream.on('close', function () {
+					console.error = origConsoleError;
+					resolve();
+				});
+				dest.catchEarlyExitAttached = true; // silence exceptions
+				dest.pipe(zipStream);
+
+				this.logger.info('Creating module zip');
+
+				// 1. documentation folder
+				const mdRegExp = /\.md$/;
+				if (fs.existsSync(this.documentationDir)) {
+					(function walk(dir, parent) {
+						if (!fs.existsSync(dir)) {
 							return;
 						}
-						if (fs.statSync(file).isDirectory()) {
-							return walk(file, path.join(parent, name));
+
+						fs.readdirSync(dir).forEach(function (name) {
+							const file = path.join(dir, name);
+							if (!fs.existsSync(file)) {
+								return;
+							}
+							if (fs.statSync(file).isDirectory()) {
+								return walk(file, path.join(parent, name));
+							}
+
+							let contents = fs.readFileSync(file).toString();
+
+							if (mdRegExp.test(name)) {
+								contents = markdown.toHTML(contents);
+								name = name.replace(/\.md$/, '.html');
+							}
+
+							dest.append(contents, { name: path.join(parent, name) });
+						});
+					}(this.documentationDir, path.join(moduleFolders, 'documentation')));
+				}
+
+				// 2. example folder
+				if (fs.existsSync(this.exampleDir)) {
+					this.dirWalker(this.exampleDir, function (file) {
+						dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'example', path.relative(this.exampleDir, file)) });
+					}.bind(this));
+				}
+
+				// 3. platform folder
+				if (fs.existsSync(this.platformDir)) {
+					dest.directory(
+						this.platformDir,
+						path.join(moduleFolders, 'platform'),
+						(entryData) => (entryData.name === 'README.md' ? false : entryData)
+					);
+				}
+
+				// 4. hooks folder
+				const hookFiles = {};
+				const suppressSpmHook = !!this.spmMetadata;
+				if (fs.existsSync(this.hooksDir)) {
+					this.dirWalker(this.hooksDir, function (file) {
+						const relFile = path.relative(this.hooksDir, file);
+						if (suppressSpmHook && relFile === 'ti.spm.js') {
+							this.logger.debug('Skipping legacy ti.spm hook because Swift package metadata is embedded in metadata.json');
+							return;
 						}
-
-						let contents = fs.readFileSync(file).toString();
-
-						if (mdRegExp.test(name)) {
-							contents = markdown.toHTML(contents);
-							name = name.replace(/\.md$/, '.html');
-						}
-
-						dest.append(contents, { name: path.join(parent, name) });
-					});
-				}(this.documentationDir, path.join(moduleFolders, 'documentation')));
-			}
-
-			// 2. example folder
-			if (fs.existsSync(this.exampleDir)) {
-				this.dirWalker(this.exampleDir, function (file) {
-					dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'example', path.relative(this.exampleDir, file)) });
-				}.bind(this));
-			}
-
-			// 3. platform folder
-			if (fs.existsSync(this.platformDir)) {
-				dest.directory(
-					this.platformDir,
-					path.join(moduleFolders, 'platform'),
-					(entryData) => (entryData.name === 'README.md' ? false : entryData)
-				);
-			}
-
-			// 4. hooks folder
-			const hookFiles = {};
-			const suppressSpmHook = !!this.spmMetadata;
-			if (fs.existsSync(this.hooksDir)) {
-				this.dirWalker(this.hooksDir, function (file) {
-					const relFile = path.relative(this.hooksDir, file);
-					if (suppressSpmHook && relFile === 'ti.spm.js') {
-						this.logger.debug('Skipping legacy ti.spm hook because Swift package metadata is embedded in metadata.json');
-						return;
-					}
-					hookFiles[relFile] = 1;
-					dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'hooks', relFile) });
-				}.bind(this));
-			}
-			if (fs.existsSync(this.sharedHooksDir)) {
-				this.dirWalker(this.sharedHooksDir, function (file) {
-					const relFile = path.relative(this.sharedHooksDir, file);
-					if (suppressSpmHook && relFile === 'ti.spm.js') {
-						return;
-					}
-					if (!hookFiles[relFile]) {
+						hookFiles[relFile] = 1;
 						dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'hooks', relFile) });
-					}
-				}.bind(this));
+					}.bind(this));
+				}
+				if (fs.existsSync(this.sharedHooksDir)) {
+					this.dirWalker(this.sharedHooksDir, function (file) {
+						const relFile = path.relative(this.sharedHooksDir, file);
+						if (suppressSpmHook && relFile === 'ti.spm.js') {
+							return;
+						}
+						if (!hookFiles[relFile]) {
+							dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'hooks', relFile) });
+						}
+					}.bind(this));
+				}
+
+				// 5. Resources folder
+				if (fs.existsSync(this.resourcesDir)) {
+					this.dirWalker(this.resourcesDir, function (file, name) {
+						if (name !== 'README.md') {
+							dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'Resources', path.relative(this.resourcesDir, file)) });
+						}
+					}.bind(this));
+				}
+
+				// 6. assets folder, not including JS files
+				if (fs.existsSync(this.assetsDir)) {
+					this.dirWalker(this.assetsDir, function (file) {
+						if (path.extname(file) !== '.js') {
+							dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'assets', path.relative(this.assetsDir, file)) });
+						}
+					}.bind(this));
+				}
+
+				// 7. Add the xcframework dir
+				// DO NOT WALK THE DIR! Include it as-is to preserve the folder/file symlinks used by mac catalsyt frameworks!
+				dest.directory(binarylibFile, path.join(moduleFolders, binarylibName));
+
+				// 8. LICENSE file
+				if (fs.existsSync(this.licenseFile)) {
+					dest.append(fs.createReadStream(this.licenseFile), { name: path.join(moduleFolders, 'LICENSE') });
+				} else {
+					this.logger.warn('Missing LICENSE file in the module\'s project root. We recommend to include the file to ensure proper OSS compliance.');
+				}
+
+				// 9. manifest
+				dest.append(fs.createReadStream(this.manifestFile), { name: path.join(moduleFolders, 'manifest') });
+
+				// 10. module.xcconfig
+				if (fs.existsSync(this.moduleXcconfigFile)) {
+					let contents = fs.readFileSync(this.moduleXcconfigFile).toString();
+
+					contents = '// This flag is generated by the module build, do not change it.\nTI_MODULE_VERSION=' + this.moduleVersion + '\n\n' + contents;
+
+					dest.append(contents, { name: path.join(moduleFolders, 'module.xcconfig') });
+				}
+
+				// 11. metadata.json
+				dest.append(fs.createReadStream(this.metaDataFile), { name: path.join(moduleFolders, 'metadata.json') });
+
+				this.logger.info(`Writing module zip: ${moduleZipFullPath}`);
+				dest.finalize();
+			} finally {
+				console.error = origConsoleError;
 			}
-
-			// 5. Resources folder
-			if (fs.existsSync(this.resourcesDir)) {
-				this.dirWalker(this.resourcesDir, function (file, name) {
-					if (name !== 'README.md') {
-						dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'Resources', path.relative(this.resourcesDir, file)) });
-					}
-				}.bind(this));
-			}
-
-			// 6. assets folder, not including JS files
-			if (fs.existsSync(this.assetsDir)) {
-				this.dirWalker(this.assetsDir, function (file) {
-					if (path.extname(file) !== '.js') {
-						dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'assets', path.relative(this.assetsDir, file)) });
-					}
-				}.bind(this));
-			}
-
-			// 7. Add the xcframework dir
-			// DO NOT WALK THE DIR! Include it as-is to preserve the folder/file symlinks used by mac catalsyt frameworks!
-			dest.directory(binarylibFile, path.join(moduleFolders, binarylibName));
-
-			// 8. LICENSE file
-			if (fs.existsSync(this.licenseFile)) {
-				dest.append(fs.createReadStream(this.licenseFile), { name: path.join(moduleFolders, 'LICENSE') });
-			} else {
-				this.logger.warn('Missing LICENSE file in the module\'s project root. We recommend to include the file to ensure proper OSS compliance.');
-			}
-
-			// 9. manifest
-			dest.append(fs.createReadStream(this.manifestFile), { name: path.join(moduleFolders, 'manifest') });
-
-			// 10. module.xcconfig
-			if (fs.existsSync(this.moduleXcconfigFile)) {
-				let contents = fs.readFileSync(this.moduleXcconfigFile).toString();
-
-				contents = '// This flag is generated by the module build, do not change it.\nTI_MODULE_VERSION=' + this.moduleVersion + '\n\n' + contents;
-
-				dest.append(contents, { name: path.join(moduleFolders, 'module.xcconfig') });
-			}
-
-			// 11. metadata.json
-			dest.append(fs.createReadStream(this.metaDataFile), { name: path.join(moduleFolders, 'metadata.json') });
-
-			this.logger.info(`Writing module zip: ${moduleZipFullPath}`);
-			dest.finalize();
-		} finally {
-			console.error = origConsoleError;
-		}
+		});
 	}
 
-	runModule(cli, next) {
+	async runModule(cli) {
 		if (this.buildOnly) {
-			return next();
+			return;
 		}
 
 		const tmpDir = temp.path('ti-ios-module-build-'),
@@ -1230,102 +1224,101 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 			});
 		}
 
-		function runTiCommand(args, callback) {
+		async function runTiCommand(args) {
 			logger.debug(`Running: ${('titanium ' + args.join(' ')).cyan}`);
 			const child = spawn('titanium', args);
 
 			child.stdout.on('data', log);
 			child.stderr.on('data', log);
 
-			child.on('close', function (code) {
-				if (code) {
-					logger.error(`Failed to run ti ${args[0]}`);
-					logger.log();
-					process.exit(1);
-				}
-				callback();
+			return new Promise((resolve) => {
+				child.on('close', function (code) {
+					if (code) {
+						logger.error(`Failed to run ti ${args[0]}`);
+						logger.log();
+						process.exit(1);
+					}
+					resolve();
+				});
 			});
 		}
 
-		series(this, [
-			function (cb) {
-				// 1. create temp dir
-				fs.ensureDirSync(tmpDir);
+		// 1. create temp dir
+		fs.ensureDirSync(tmpDir);
 
-				// 2. create temp proj
-				// Forward --sdk so the test app uses the same SDK the module was built with,
-				// otherwise the CLI defaults to the latest GA which may be a different version.
-				this.logger.debug(`Staging module project at ${tmpDir.cyan}`);
-				const createArgs = [
-					'create',
-					'--id', this.moduleId,
-					'-n', this.moduleName,
-					'-t', 'app',
-					'-u', 'localhost',
-					'-d', tmpDir,
-					'-p', 'ios',
-					'--force',
-					'--no-prompt',
-					'--no-progress-bars',
-					'--no-colors'
-				];
-				if (this.titaniumSdkVersion) {
-					createArgs.push('--sdk', this.titaniumSdkVersion);
-				}
-				runTiCommand(createArgs, cb);
-			},
+		// 2. create temp proj
+		// Forward --sdk so the test app uses the same SDK the module was built with,
+		// otherwise the CLI defaults to the latest GA which may be a different version.
+		this.logger.debug(`Staging module project at ${tmpDir.cyan}`);
+		const createArgs = [
+			'create',
+			'--id', this.moduleId,
+			'-n', this.moduleName,
+			'-t', 'app',
+			'-u', 'localhost',
+			'-d', tmpDir,
+			'-p', 'ios',
+			'--force',
+			'--no-prompt',
+			'--no-progress-bars',
+			'--no-colors'
+		];
+		if (this.titaniumSdkVersion) {
+			createArgs.push('--sdk', this.titaniumSdkVersion);
+		}
+		await runTiCommand(createArgs);
 
-			function (cb) {
-				this.logger.debug(`Created temp project ${tmpProjectDir.cyan}`);
+		this.logger.debug(`Created temp project ${tmpProjectDir.cyan}`);
 
-				// 3. patch tiapp.xml with module id
-				const data = fs.readFileSync(path.join(tmpProjectDir, 'tiapp.xml')).toString();
-				const result = data.replace(/<modules>/g, '<modules>\n\t\t<module platform="iphone">' + this.moduleId + '</module>');
-				fs.writeFileSync(path.join(tmpProjectDir, 'tiapp.xml'), result);
+		// 3. patch tiapp.xml with module id
+		const data = fs.readFileSync(path.join(tmpProjectDir, 'tiapp.xml')).toString();
+		const result = data.replace(/<modules>/g, '<modules>\n\t\t<module platform="iphone">' + this.moduleId + '</module>');
+		fs.writeFileSync(path.join(tmpProjectDir, 'tiapp.xml'), result);
 
-				// 4. copy files in example to Resource
-				appc.fs.copyDirSyncRecursive(
-					this.exampleDir,
-					path.join(tmpProjectDir, 'Resources'),
-					{
-						preserve: true,
-						logger: this.logger.debug
-					}
-				);
-
-				// 5. unzip module to the tmp dir
-				appc.zip.unzip(this.moduleZipPath, tmpProjectDir, null, cb);
-			},
-
-			// Emit hook so modules can also alter project before launch
-			function (cb) {
-				cli.emit('create.module.app.finalize', [ this, tmpProjectDir ], cb);
-			},
-
-			function (cb) {
-				// 6. run the app
-				this.logger.debug(`Running example project... ${tmpDir.cyan}`);
-				const buildArgs = [
-					'build',
-					'-p', 'ios',
-					'-d', tmpProjectDir,
-					'--no-prompt',
-					'--no-colors',
-					'--no-progress-bars'
-				];
-
-				if (this.target) {
-					buildArgs.push('-T', this.target);
-				}
-				if (this.deviceId) {
-					buildArgs.push('-C', this.deviceId);
-				}
-				if (this.titaniumSdkVersion) {
-					buildArgs.push('--sdk', this.titaniumSdkVersion);
-				}
-				runTiCommand(buildArgs, cb);
+		// 4. copy files in example to Resource
+		appc.fs.copyDirSyncRecursive(
+			this.exampleDir,
+			path.join(tmpProjectDir, 'Resources'),
+			{
+				preserve: true,
+				logger: this.logger.debug
 			}
-		], next);
+		);
+
+		// 5. unzip module to the tmp dir
+		await new Promise((resolve, reject) => {
+			appc.zip.unzip(this.moduleZipPath, tmpProjectDir, null, (err) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve();
+				}
+			});
+		});
+
+		await cli.emit('create.module.app.finalize', [ this, tmpProjectDir ]);
+
+		// 6. run the app
+		this.logger.debug(`Running example project... ${tmpDir.cyan}`);
+		const buildArgs = [
+			'build',
+			'-p', 'ios',
+			'-d', tmpProjectDir,
+			'--no-prompt',
+			'--no-colors',
+			'--no-progress-bars'
+		];
+
+		if (this.target) {
+			buildArgs.push('-T', this.target);
+		}
+		if (this.deviceId) {
+			buildArgs.push('-C', this.deviceId);
+		}
+		if (this.titaniumSdkVersion) {
+			buildArgs.push('--sdk', this.titaniumSdkVersion);
+		}
+		await runTiCommand(buildArgs);
 	}
 
 	scrubbedName(name) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "ssri": "13.0.1",
         "stream-splitter": "0.3.2",
         "strip-ansi": "7.2.0",
-        "titanium": "9.0.0",
+        "titanium": "^9.1.0",
         "titanium-docgen": "5.0.0"
       }
     },
@@ -6233,27 +6233,27 @@
       }
     },
     "node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.1.tgz",
+      "integrity": "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
         "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
+        "get-stream": "^9.0.1",
         "human-signals": "^8.0.1",
         "is-plain-obj": "^4.1.0",
         "is-stream": "^4.0.1",
         "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
+        "pretty-ms": "^9.3.0",
         "signal-exit": "^4.1.0",
         "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
+        "which-command": "^0.1.0",
+        "yoctocolors": "^2.1.2"
       },
       "engines": {
-        "node": "^18.19.0 || >=20.5.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -13968,21 +13968,21 @@
       }
     },
     "node_modules/titanium": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/titanium/-/titanium-9.0.0.tgz",
-      "integrity": "sha512-Yk0xbcZYRC8UhsxilpUHfx0g+l4u89b07QK8KCT2bWL1LnEzebCaRq06H2gJmYcsraOYh1XTh95yXhFU3oq8Jg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/titanium/-/titanium-9.1.0.tgz",
+      "integrity": "sha512-IY5+aAciYmp3rydaGVmXjbSMYMGeOkRxmd31M3lAlUNVzjh9FKuVJUXL2SxFmn+P17MSFrgadfGVcwbNqkXpSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "0.9.10",
         "chalk": "5.6.2",
         "commander": "15.0.0",
-        "execa": "9.6.1",
-        "fs-extra": "11.3.5",
+        "execa": "10.0.1",
+        "fs-extra": "11.3.6",
         "pretty-bytes": "7.1.0",
         "prompts": "2.4.2",
-        "semver": "7.8.4",
-        "undici": "8.5.0",
+        "semver": "7.8.5",
+        "undici": "8.10.0",
         "which": "7.0.0",
         "wrap-ansi": "10.0.0",
         "xpath": "0.0.34",
@@ -14060,9 +14060,9 @@
       }
     },
     "node_modules/titanium/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14082,19 +14082,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/titanium/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/titanium/node_modules/which": {
@@ -14463,9 +14450,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14748,6 +14735,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-command": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+      "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "which-command": "cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/which-command?sponsor=1"
       }
     },
     "node_modules/which-module": {
@@ -15085,9 +15088,9 @@
       }
     },
     "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test:android": "npm run cleanbuild:android -- --skip-zip --no-docs --symlink && npm run test:integration -- android --sdk-version $npm_package_version",
     "test:android:onlyFailed": "npm run cleanbuild:android -- --skip-zip --no-docs --symlink && npm run test:integration -- android --sdk-version $npm_package_version --only-failed",
     "test:android:trace": "npm run cleanbuild:android -- --skip-zip --no-docs --symlink && npm run test:integration -- android --sdk-version $npm_package_version --log-level trace",
-    "test:cli": "JUNIT_REPORT_PATH=junit.cli.report.xml nyc mocha **/cli/tests/test-*.js build/**/test-*.js",
+    "test:cli": "JUNIT_REPORT_PATH=junit.cli.report.xml nyc mocha cli/tests/test-*.js **/cli/tests/test-*.js build/**/test-*.js",
     "test:ios": "npm run test:iphone",
     "test:ios:onlyFailed": "npm run test:iphone:onlyFailed",
     "test:ios:trace": "npm run test:iphone:trace",
@@ -151,7 +151,7 @@
     "ssri": "13.0.1",
     "stream-splitter": "0.3.2",
     "strip-ansi": "7.2.0",
-    "titanium": "9.0.0",
+    "titanium": "^9.1.0",
     "titanium-docgen": "5.0.0"
   },
   "overrides": {
@@ -162,7 +162,7 @@
     "url": "git://github.com/tidev/titanium_mobile.git"
   },
   "vendorDependencies": {
-    "node": ">=20.18.1"
+    "node": ">=22.19.0"
   },
   "nyc": {
     "exclude": [
@@ -174,5 +174,9 @@
       "text"
     ]
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "allowScripts": {
+    "core-js@3.50.0": true,
+    "fsevents@2.3.3": true
+  }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This PR will require Titanium CLI 9.1.0, which could be considered a breaking change and thus, this PR MUST go in the SDK 14 release.

This PR does two major things:
1. Refactor command `validate()` and `run()` functions to be async/await instead of callback-based.
2. Move `Builder` class and some `titanium` namespace functions from `node-titanium-sdk` into the SDK:
  - `loadPlugins()`
  - `resolvePlatform()`
  - `validateModuleManifest()`
  - `validatePlatformOptions()`
  - and the SDK `manifest.json` loading

Making those function async/await unlocks the next wave of improvements which includes getting rid of the `async` dependency.

We are also looking to get rid of `node-titanium-sdk`, so starting to move some of the `titanium` namespace stuff to the SDK. There are still some stuff left to move over in the future.
