### PR TITLE
feat(ios): parity for Matrix2D.rotate(from, to)

### DIFF
--- a/apidoc/Titanium/UI/Matrix2D.yml
+++ b/apidoc/Titanium/UI/Matrix2D.yml
@@ -75,8 +75,8 @@ methods:
         or two are specified.
 
         *   `rotate(angle)`. The standard `rotate` method.
-        *   `rotate(fromAngle, toAngle)`. Android only. Used for specifying rotation
-            animations.
+        *   `rotate(fromAngle, toAngle)`. Used for specifying rotation animations.
+            Android and, as of Titanium SDK 14.0.0, iOS.
 
         In both cases, a positive value specifies clockwise rotation and a negative value
         specifies counter-clockwise rotation.
@@ -94,8 +94,8 @@ methods:
         Note that if you specify a rotation matrix as the `transform` property of an
         animation, the animation animates the view from its current rotation to the
         rotation represented by the matrix by its shortest path. So to rotate a view
-        in a complete circle, the easiest method is to chain together three animations,
-        rotating 120 degrees each time.
+        in a complete circle, use `rotate(fromAngle, toAngle)` instead, for example
+        `rotate(0, 360)`.
 
         For the purposes of animation, it should be noted that the rotation angle is
         normalized to the range -180 <= angle < 180. In other
@@ -103,28 +103,34 @@ methods:
         except when determining which direction an animation rotates. 179 degrees rotates
         rotate clockwise, but 180 degrees is normalized to -180, so rotates counter-clockwise.
 
-        #### rotate(angle, toAngle) -- Android Only
+        #### rotate(angle, toAngle)
 
-        This is an Android-specific method used for creating rotation animations.
+        This method is used for creating rotation animations. It is supported on Android and,
+        as of Titanium SDK 14.0.0, on iOS.
         Returns a `Matrix2D` object that represents a rotation from `angle` to `toAngle`.
 
         Angles are specified in degrees. Positive values represent clockwise rotation, and negative values
         represent counter-clockwise rotation. Values are not normalized, so for example an
         angle of 720 degrees represents two complete clockwise revolutions.
 
-        The resulting object cannot be expressed as an affine transform, but can be used with the
-        <Titanium.UI.Animation.transform> property to specify a rotation animation.
+        On Android, the resulting object cannot be expressed as an affine transform. On iOS, the
+        resulting matrix expresses the final (`toAngle`) transform and additionally carries the
+        starting angle. In both cases the object can be used with the
+        <Titanium.UI.Animation.transform> property to specify a rotation animation that follows
+        the full angular path, for example `rotate(0, 360)` for a complete clockwise revolution.
     returns:
         type: Titanium.UI.Matrix2D
     parameters:
       - name: angle
         summary: |
-            Angle to rotate to, in degrees. On Android, if `toAngle` is specified, this specifies
+            Angle to rotate to, in degrees. If `toAngle` is specified, this specifies
             the starting angle for a rotation animation.
         type: Number
 
       - name: toAngle
-        summary: Ending angle for a rotation animation, in degrees. Android only.
+        summary: |
+            Ending angle for a rotation animation, in degrees.
+            Supported on iOS since Titanium SDK 14.0.0.
         type: Number
         optional: true
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/Ti2DMatrix.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/Ti2DMatrix.h
@@ -13,6 +13,9 @@
 @interface Ti2DMatrix : TiProxy {
   @protected
   CGAffineTransform matrix;
+  BOOL hasRotationAnimationValues;
+  CGFloat rotationAnimationFromDegrees;
+  CGFloat rotationAnimationToDegrees;
 }
 
 /**
@@ -45,5 +48,21 @@
 @property (nonatomic, readwrite, retain) NSNumber *d;
 @property (nonatomic, readwrite, retain) NSNumber *tx;
 @property (nonatomic, readwrite, retain) NSNumber *ty;
+
+/**
+ YES if this matrix was created via rotate(fromAngle, toAngle) and therefore
+ carries explicit start/end angles for a rotation animation.
+ */
+@property (nonatomic, readonly) BOOL hasRotationAnimationValues;
+
+/**
+ Starting angle, in degrees, of a rotate(fromAngle, toAngle) animation.
+ */
+@property (nonatomic, readonly) CGFloat rotationAnimationFromDegrees;
+
+/**
+ Ending angle, in degrees, of a rotate(fromAngle, toAngle) animation.
+ */
+@property (nonatomic, readonly) CGFloat rotationAnimationToDegrees;
 
 @end

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/Ti2DMatrix.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/Ti2DMatrix.m
@@ -11,6 +11,10 @@
 
 @implementation Ti2DMatrix
 
+@synthesize hasRotationAnimationValues;
+@synthesize rotationAnimationFromDegrees;
+@synthesize rotationAnimationToDegrees;
+
 - (id)init
 {
   if (self = [super init]) {
@@ -52,6 +56,15 @@
   return matrix;
 }
 
+- (Ti2DMatrix *)matrixWithTransform:(CGAffineTransform)newTransform
+{
+  Ti2DMatrix *newMatrix = [[[Ti2DMatrix alloc] initWithMatrix:newTransform] autorelease];
+  newMatrix->hasRotationAnimationValues = hasRotationAnimationValues;
+  newMatrix->rotationAnimationFromDegrees = rotationAnimationFromDegrees;
+  newMatrix->rotationAnimationToDegrees = rotationAnimationToDegrees;
+  return newMatrix;
+}
+
 - (Ti2DMatrix *)translate:(id)args
 {
   // Fetch given coordinates.
@@ -64,7 +77,7 @@
 
   // Return a new matrix with the given translation applied to this matrix.
   CGAffineTransform newtransform = CGAffineTransformTranslate(matrix, tx, ty);
-  return [[[Ti2DMatrix alloc] initWithMatrix:newtransform] autorelease];
+  return [self matrixWithTransform:newtransform];
 }
 
 - (Ti2DMatrix *)scale:(id)args
@@ -77,7 +90,7 @@
   if (sy == 0)
     sy = 0.0001;
   CGAffineTransform newtransform = CGAffineTransformScale(matrix, sx, sy);
-  return [[[Ti2DMatrix alloc] initWithMatrix:newtransform] autorelease];
+  return [self matrixWithTransform:newtransform];
 }
 
 - (Ti2DMatrix *)rotate:(id)args
@@ -85,6 +98,17 @@
   ENSURE_ARG_COUNT(args, 1);
 
   CGFloat angle = [[args objectAtIndex:0] floatValue];
+  if ([args count] >= 2) {
+    // rotate(fromAngle, toAngle): the matrix expresses the final ("toAngle")
+    // transform; the angles are kept so TiAnimation can follow the full angular
+    // path (e.g. 0 -> 360) instead of the shortest one.
+    CGFloat toAngle = [[args objectAtIndex:1] floatValue];
+    Ti2DMatrix *newMatrix = [[[Ti2DMatrix alloc] initWithMatrix:CGAffineTransformRotate(matrix, degreesToRadians(toAngle))] autorelease];
+    newMatrix->hasRotationAnimationValues = YES;
+    newMatrix->rotationAnimationFromDegrees = angle;
+    newMatrix->rotationAnimationToDegrees = toAngle;
+    return newMatrix;
+  }
   CGAffineTransform newtransform = CGAffineTransformRotate(matrix, degreesToRadians(angle));
   return [[[Ti2DMatrix alloc] initWithMatrix:newtransform] autorelease];
 }

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiAnimation.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiAnimation.m
@@ -415,6 +415,19 @@
     options |= ([autoreverse boolValue] ? (UIViewAnimationOptionAutoreverse | UIViewAnimationOptionRepeat) : 0);
     options |= (([repeat intValue] > 0) ? UIViewAnimationOptionRepeat : 0);
 
+    // A matrix made via rotate(fromAngle, toAngle) must follow the full angular path,
+    // which is driven by an explicit CAAnimation whose transaction fires the completion.
+    BOOL animatesRotationPath = [transform isKindOfClass:[Ti2DMatrix class]] && [(Ti2DMatrix *)transform hasRotationAnimationValues];
+
+    void (^complete)(BOOL) = ^(BOOL finished) {
+      if ((reverseAnimation != nil) && ![self isReverse] && finished) {
+        [reverseAnimation animate:args];
+        RELEASE_TO_NIL(reverseAnimation);
+      } else {
+        [self animationCompleted:[self description] finished:[NSNumber numberWithBool:finished] context:self];
+      }
+    };
+
     void (^animation)(void) = ^{
       CGFloat repeatCount = [repeat intValue];
       if ((options & UIViewAnimationOptionAutoreverse)) {
@@ -480,19 +493,59 @@
           }
           [reverseAnimation setTransform:transformMatrix];
         }
-        if ([transform isKindOfClass:[Ti2DMatrix class]]) {
-          // Special handling if matrix does an exact 180 or -180 degree rotation.
-          // Forward animation and final reverse animation will never rotate counter-clockwise in this case.
-          // Work-around is to slightly offset the rotation. (This won't affect rotation back to 0 degrees.)
-          const float ROTATION_EPSILON = 0.01f;
+        if (animatesRotationPath) {
+          // rotate(fromAngle, toAngle): UIKit interpolates an affine transform along the
+          // shortest path, so e.g. a full turn (0 -> 360) would not move at all. Set the
+          // final transform without implicit animation and drive the rotation through a
+          // CAKeyframeAnimation sampling the angular path in steps of at most 90 degrees,
+          // so every segment interpolates in the intended direction.
           Ti2DMatrix *transformMatrix = (Ti2DMatrix *)transform;
-          float degrees = radiansToDegrees(atan2f([[transformMatrix b] floatValue], [[transformMatrix a] floatValue]));
-          if ((fabsf(degrees) + ROTATION_EPSILON) >= 180.0f) {
-            NSNumber *degreeOffset = [NSNumber numberWithFloat:((degrees > 0) ? -ROTATION_EPSILON : ROTATION_EPSILON)];
-            [self setTransform:[transformMatrix rotate:[NSArray arrayWithObject:degreeOffset]]];
+          [UIView performWithoutAnimation:^{
+            [(TiUIView *)view_ setTransform_:transform];
+          }];
+
+          CGFloat fromDegrees = [transformMatrix rotationAnimationFromDegrees];
+          CGFloat toDegrees = [transformMatrix rotationAnimationToDegrees];
+          NSUInteger segments = MAX((NSUInteger)ceil(fabs(toDegrees - fromDegrees) / 90.0), (NSUInteger)1);
+          NSMutableArray *values = [NSMutableArray arrayWithCapacity:segments + 1];
+          for (NSUInteger i = 0; i <= segments; i++) {
+            // Note: the degreesToRadians() macro does not parenthesize its argument.
+            CGFloat degreesBeforeEnd = (fromDegrees - toDegrees) * (segments - i) / segments;
+            CGAffineTransform stepTransform = CGAffineTransformRotate([transformMatrix matrix], degreesToRadians(degreesBeforeEnd));
+            [values addObject:[NSValue valueWithCATransform3D:CATransform3DMakeAffineTransform(stepTransform)]];
           }
+
+          CAKeyframeAnimation *rotationAnimation = [CAKeyframeAnimation animationWithKeyPath:@"transform"];
+          rotationAnimation.values = values;
+          rotationAnimation.duration = animationDuration;
+          rotationAnimation.timingFunction = [self timingFunction];
+          rotationAnimation.beginTime = CACurrentMediaTime() + ([delay doubleValue] / 1000);
+          rotationAnimation.fillMode = kCAFillModeBackwards;
+          rotationAnimation.autoreverses = ((options & UIViewAnimationOptionAutoreverse) != 0);
+          if ((options & UIViewAnimationOptionRepeat) != 0) {
+            rotationAnimation.repeatCount = (repeatCount != 0.0) ? repeatCount : 1.0;
+          }
+          [CATransaction begin];
+          [CATransaction setCompletionBlock:^{
+            complete(YES);
+          }];
+          [view_.layer addAnimation:rotationAnimation forKey:@"TiRotationAnimation"];
+          [CATransaction commit];
+        } else {
+          if ([transform isKindOfClass:[Ti2DMatrix class]]) {
+            // Special handling if matrix does an exact 180 or -180 degree rotation.
+            // Forward animation and final reverse animation will never rotate counter-clockwise in this case.
+            // Work-around is to slightly offset the rotation. (This won't affect rotation back to 0 degrees.)
+            const float ROTATION_EPSILON = 0.01f;
+            Ti2DMatrix *transformMatrix = (Ti2DMatrix *)transform;
+            float degrees = radiansToDegrees(atan2f([[transformMatrix b] floatValue], [[transformMatrix a] floatValue]));
+            if ((fabsf(degrees) + ROTATION_EPSILON) >= 180.0f) {
+              NSNumber *degreeOffset = [NSNumber numberWithFloat:((degrees > 0) ? -ROTATION_EPSILON : ROTATION_EPSILON)];
+              [self setTransform:[transformMatrix rotate:[NSArray arrayWithObject:degreeOffset]]];
+            }
+          }
+          [(TiUIView *)view_ setTransform_:transform];
         }
-        [(TiUIView *)view_ setTransform_:transform];
       }
 
       if ([view_ isKindOfClass:[TiUIView class]]) { // TODO: Shouldn't we be updating the proxy's properties to reflect this?
@@ -630,14 +683,14 @@
       }
     };
 
-    void (^complete)(BOOL) = ^(BOOL finished) {
-      if ((reverseAnimation != nil) && ![self isReverse] && finished) {
-        [reverseAnimation animate:args];
-        RELEASE_TO_NIL(reverseAnimation);
-      } else {
-        [self animationCompleted:[self description] finished:[NSNumber numberWithBool:finished] context:self];
-      }
-    };
+    // When the rotation is driven by an explicit CAAnimation, its transaction fires the
+    // completion; the UIView animation may have nothing left to animate, in which case
+    // its completion block would run immediately.
+    void (^uiViewComplete)(BOOL) = complete;
+    if (animatesRotationPath) {
+      uiViewComplete = ^(BOOL finished) {
+      };
+    }
 
     if (dampingRatio != nil || springVelocity != nil) {
 #ifdef __IPHONE_17_0
@@ -648,7 +701,7 @@
                                     delay:([delay doubleValue] / 1000)
                                   options:options
                                animations:animation
-                               completion:complete];
+                               completion:uiViewComplete];
       } else {
 #endif
         [UIView animateWithDuration:animationDuration
@@ -657,7 +710,7 @@
               initialSpringVelocity:[springVelocity floatValue]
                             options:options
                          animations:animation
-                         completion:complete];
+                         completion:uiViewComplete];
 #ifdef __IPHONE_17_0
       }
 #endif
@@ -666,7 +719,7 @@
                             delay:([delay doubleValue] / 1000)
                           options:options
                        animations:animation
-                       completion:complete];
+                       completion:uiViewComplete];
     }
 
   } else {

--- a/tests/Resources/ti.ui.matrix2d.test.js
+++ b/tests/Resources/ti.ui.matrix2d.test.js
@@ -64,6 +64,21 @@ describe('Titanium.UI.Matrix2D', function () {
 		should(matrix1.rotate(-0)).be.an.Object();
 	});
 
+	it('#rotate(fromAngle, toAngle)', function () {
+		var matrix1 = Ti.UI.createMatrix2D();
+		should(matrix1.rotate(0, 360)).be.an.Object();
+		should(matrix1.rotate(90, -90)).be.an.Object();
+		should(matrix1.rotate(-360, 720)).be.an.Object();
+		if (utilities.isIOS()) {
+			// The resulting matrix expresses the final ("toAngle") transform.
+			var rotated = matrix1.rotate(0, 90);
+			should(rotated.a).be.approximately(0, 0.0001);
+			should(rotated.b).be.approximately(1, 0.0001);
+			should(rotated.c).be.approximately(-1, 0.0001);
+			should(rotated.d).be.approximately(0, 0.0001);
+		}
+	});
+
 	it('#scale()', function () {
 		var matrix1 = Ti.UI.createMatrix2D();
 		should(matrix1.scale(50, 50)).be.an.Object();


### PR DESCRIPTION
Parity for `Ti.UI.createMatrix2D().rotate(0, 360)` (currently only supported on Android): https://titaniumsdk.com/api/titanium/ui/matrix2d.html#rotate-angle-toangle-android-only

**Test code**
```js
var win = Ti.UI.createWindow({ });

var v = Ti.UI.createView({
    width: 100,
    height: 100,
    backgroundColor:"red"
})
win.add(v);

var a = Ti.UI.createAnimation({
    transform: Ti.UI.createMatrix2D().rotate(0, 360),
    duration: 2000,
    curve: Ti.UI.ANIMATION_CURVE_LINEAR,
    repeat: 1000
});
v.animate(a);

/*
// old way - two step animation

var t1 = Ti.UI.createMatrix2D().rotate(180);
var t2 = Ti.UI.createMatrix2D().rotate(359);

function spin() {
    v.animate({ transform: t1, duration: 1000, curve: Ti.UI.ANIMATION_CURVE_LINEAR }, function () {
        v.animate({ transform: t2, duration: 1000, curve: Ti.UI.ANIMATION_CURVE_LINEAR }, function () {
            // reset to identity instantly, then loop
            v.transform = Ti.UI.createMatrix2D();
            spin();
        });
    });
}
win.addEventListener('open', spin);
*/
win.open();
```

Allows the user to define a from - to rotation (full 360 deg) with one rotate call.