### PR TITLE
feat(android): merge module build.gradle repositories

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2163,7 +2163,7 @@ class AndroidBuilder extends Builder {
 		await fs.writeFile(path.join(projectDirPath, 'build.gradle'), buildGradleContent);
 	}
 
-	async fetchMergeModuleMavenRepositoriesSetting() {
+	async shouldMergeModuleMavenRepositories() {
 		// Determines if Maven repository URLs defined by modules should be added to the app project.
 		// This is enabled by default. App developers can opt out via the below "tiapp.xml" setting:
 		//   <android><merge-module-maven-repositories>false</merge-module-maven-repositories></android>
@@ -2185,7 +2185,8 @@ class AndroidBuilder extends Builder {
 				return String(settingValue).trim().toLowerCase() !== 'false';
 			}
 		} catch (err) {
-			this.logger.warn(`Failed to read "merge-module-maven-repositories" setting from "tiapp.xml" file. Reason:\n${err}`);
+			this.logger.error(`Failed to read "merge-module-maven-repositories" setting from "tiapp.xml" file. Reason:\n${err}`);
+			throw err;
 		}
 		return true;
 	}
@@ -2208,7 +2209,7 @@ class AndroidBuilder extends Builder {
 		this.libDependencyStrings.push(`org.appcelerator:titanium:${this.titaniumSdkVersion}`);
 
 		// Check if the app developer opted out of adding module defined Maven repositories to the app project.
-		const isModuleRepoMergeEnabled = await this.fetchMergeModuleMavenRepositoriesSetting();
+		const isModuleRepoMergeEnabled = await this.shouldMergeModuleMavenRepositories();
 
 		// Process all Titanium modules referenced by the Titanium project.
 		for (const nextModule of this.modules) {

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2256,7 +2256,7 @@ class AndroidBuilder extends Builder {
 							`Skipping Maven repositories from module "${nextModule.manifest.moduleid}". `
 							+ `Was disabled via "merge-module-maven-repositories" setting in "tiapp.xml" file.`);
 					}
-				} else if (await fs.exists(mavenReposFilePath)) {
+				} else if (fs.existsSync(mavenReposFilePath)) {
 					try {
 						const repoUrls = JSON.parse(await fs.readFile(mavenReposFilePath, 'utf8'));
 						if (Array.isArray(repoUrls)) {

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2163,6 +2163,33 @@ class AndroidBuilder extends Builder {
 		await fs.writeFile(path.join(projectDirPath, 'build.gradle'), buildGradleContent);
 	}
 
+	async fetchMergeModuleMavenRepositoriesSetting() {
+		// Determines if Maven repository URLs defined by modules should be added to the app project.
+		// This is enabled by default. App developers can opt out via the below "tiapp.xml" setting:
+		//   <android><merge-module-maven-repositories>false</merge-module-maven-repositories></android>
+		// Note: Must be read from the XML directly since the tiapp parser only reads known <android/> tags.
+		try {
+			const fileContent = await fs.readFile(path.join(this.projectDir, 'tiapp.xml'), 'utf8');
+			const xmlDoc = new DOMParser().parseFromString(fileContent, 'text/xml');
+			let settingValue = null;
+			appc.xml.forEachElement(xmlDoc.documentElement, (node) => {
+				if (node.tagName === 'android') {
+					appc.xml.forEachElement(node, (childNode) => {
+						if (childNode.tagName === 'merge-module-maven-repositories') {
+							settingValue = appc.xml.getValue(childNode);
+						}
+					});
+				}
+			});
+			if (settingValue !== null) {
+				return String(settingValue).trim().toLowerCase() !== 'false';
+			}
+		} catch (err) {
+			this.logger.warn(`Failed to read "merge-module-maven-repositories" setting from "tiapp.xml" file. Reason:\n${err}`);
+		}
+		return true;
+	}
+
 	async processLibraries() {
 		this.logger.info('Processing libraries');
 
@@ -2179,6 +2206,9 @@ class AndroidBuilder extends Builder {
 		// Add a reference to the core Titanium library.
 		this.mavenRepositoryUrls.push(pathToFileURL(path.join(this.platformPath, 'm2repository')).href);
 		this.libDependencyStrings.push(`org.appcelerator:titanium:${this.titaniumSdkVersion}`);
+
+		// Check if the app developer opted out of adding module defined Maven repositories to the app project.
+		const isModuleRepoMergeEnabled = await this.fetchMergeModuleMavenRepositoriesSetting();
 
 		// Process all Titanium modules referenced by the Titanium project.
 		for (const nextModule of this.modules) {
@@ -2215,6 +2245,33 @@ class AndroidBuilder extends Builder {
 				// This supports dependency management to avoid library version conflicts.
 				this.mavenRepositoryUrls.push(pathToFileURL(repositoryDirPath).href);
 				this.libDependencyStrings.push(dependencyString);
+
+				// Add the module's custom Maven repository URLs (if any) to the app project so that the
+				// module's remote dependencies can be resolved without the app developer having to
+				// declare these repositories in the app's "platform/android/build.gradle" file manually.
+				const mavenReposFilePath = path.join(nextModule.modulePath, 'ti.maven.repos.json');
+				if (!isModuleRepoMergeEnabled) {
+					if (await fs.exists(mavenReposFilePath)) {
+						this.logger.info(
+							`Skipping Maven repositories from module "${nextModule.manifest.moduleid}". `
+							+ `Was disabled via "merge-module-maven-repositories" setting in "tiapp.xml" file.`);
+					}
+				} else if (await fs.exists(mavenReposFilePath)) {
+					try {
+						const repoUrls = JSON.parse(await fs.readFile(mavenReposFilePath, 'utf8'));
+						if (Array.isArray(repoUrls)) {
+							for (const repoUrl of repoUrls) {
+								if ((typeof repoUrl === 'string') && /^https?:\/\//.test(repoUrl)
+									&& !this.mavenRepositoryUrls.includes(repoUrl)) {
+									this.logger.info(`Adding Maven repository from module "${nextModule.manifest.moduleid}": ${repoUrl.cyan}`);
+									this.mavenRepositoryUrls.push(repoUrl);
+								}
+							}
+						}
+					} catch (err) {
+						this.logger.warn(`Failed to read Maven repository list from module "${nextModule.manifest.moduleid}". Reason:\n${err}`);
+					}
+				}
 			} else {
 				// Module directory only contains JARs/AARs. (This is our legacy module distribution.)
 				// We must create a Gradle library project and copy the module's files to it.

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2251,7 +2251,7 @@ class AndroidBuilder extends Builder {
 				// declare these repositories in the app's "platform/android/build.gradle" file manually.
 				const mavenReposFilePath = path.join(nextModule.modulePath, 'ti.maven.repos.json');
 				if (!isModuleRepoMergeEnabled) {
-					if (await fs.exists(mavenReposFilePath)) {
+					if (fs.existsSync(mavenReposFilePath)) {
 						this.logger.info(
 							`Skipping Maven repositories from module "${nextModule.manifest.moduleid}". `
 							+ `Was disabled via "merge-module-maven-repositories" setting in "tiapp.xml" file.`);

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -722,7 +722,7 @@ export class AndroidModuleBuilder extends Builder {
 		// The app build system uses this to add the module's repositories (such as jitpack) to the
 		// app project so its remote dependencies can be resolved without manual app-side changes.
 		const mavenReposFilePath = path.join(this.buildModuleDir, 'build', 'outputs', 'ti.maven.repos.json');
-		if (await fs.exists(mavenReposFilePath)) {
+		if (fs.existsSync(mavenReposFilePath)) {
 			dest.append(fs.createReadStream(mavenReposFilePath), { name: path.join(moduleFolder, 'ti.maven.repos.json') });
 		}
 

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -718,6 +718,14 @@ export class AndroidModuleBuilder extends Builder {
 			dest.append(fs.createReadStream(filePath), { name: zipEntryName });
 		});
 
+		// Add module's custom Maven repository list JSON file to the archive if it exists.
+		// The app build system uses this to add the module's repositories (such as jitpack) to the
+		// app project so its remote dependencies can be resolved without manual app-side changes.
+		const mavenReposFilePath = path.join(this.buildModuleDir, 'build', 'outputs', 'ti.maven.repos.json');
+		if (await fs.exists(mavenReposFilePath)) {
+			dest.append(fs.createReadStream(mavenReposFilePath), { name: path.join(moduleFolder, 'ti.maven.repos.json') });
+		}
+
 		// Add module's proxy binding JSON file to archive.
 		// Needed by the app build system when generating the "TiApplication" derived class to inject
 		// this module's classes into the KrollRuntime and to invoke module's onAppCreate() if defined.

--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -263,6 +263,28 @@ publishing {
 	}
 }
 
+// Writes the module's custom Maven repository URLs (such as jitpack) to a JSON file after publishing.
+// This file gets bundled into the module zip so that the app build system can add these repositories
+// to the app project automatically, without the app developer having to declare them by hand.
+tasks.register('writeTiMavenRepositories') {
+	def outputFile = file("${buildDir}/outputs/ti.maven.repos.json")
+	outputs.file(outputFile)
+	doLast {
+		// Exclude repositories the app build system already provides by default.
+		def defaultUrls = [
+			'https://dl.google.com/dl/android/maven2',
+			'https://repo.maven.apache.org/maven2'
+		]
+		def urls = project.repositories.withType(MavenArtifactRepository)
+			.collect { it.url.toString().replaceAll('/+$', '') }
+			.findAll { url -> url.startsWith('http') && !defaultUrls.contains(url) }
+			.unique()
+		outputFile.parentFile.mkdirs()
+		outputFile.text = groovy.json.JsonOutput.toJson(urls)
+	}
+}
+tasks.named('publish') { finalizedBy 'writeTiMavenRepositories' }
+
 // Load the module developer's optional "build.gradle" file from "<module>/android" directory.
 // This Gradle file is expected to provide the module's "dependencies".
 def moduleBuildGradlePath = "${projectDir}/../../build.gradle"


### PR DESCRIPTION
**Issue:**
Currently when you build a module that uses an external Maven repo like `maven { url = uri('https://jitpack.io') }` you have to ask the user to manually add those to the app too. Otherwise it will fail with something like this:

```
[ERROR] [GRADLE]
[ERROR] [GRADLE] FAILURE: Build failed with an exception.
[ERROR] [GRADLE]
[ERROR] [GRADLE] * What went wrong:
[ERROR] [GRADLE] Configuration cache state could not be cached: field `__runtimeDependenciesNavigationFiles__` of task `:app:processDebugNavigationResources` of type `com.android.build.gradle.internal.tasks.ProcessNavigationXmlTask`: error writing value of type 'org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection'
[ERROR] [GRADLE] > Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
[ERROR] [GRADLE]    > Could not find com.github.pedroSG94.RootEncoder:library:2.7.5.
[ERROR] [GRADLE]      Searched in the following locations:
[ERROR] [GRADLE]        - https://dl.google.com/dl/android/maven2/com/github/pedroSG94/RootEncoder/library/2.7.5/library-2.7.5.pom
[ERROR] [GRADLE]        - https://repo.maven.apache.org/maven2/com/github/pedroSG94/RootEncoder/library/2.7.5/library-2.7.5.pom
[ERROR] [GRADLE]        - file:/home/miga/.titanium/mobilesdk/linux/13.4.0.GA/android/m2repository/com/github/pedroSG94/RootEncoder/library/2.7.5/library-2.7.5.pom
[ERROR] [GRADLE]        - file:/tmp/ti-android-module-build-2026724-115272-yos8ep.klq2m/ti.twitch/modules/android/ti.twitch/1.0.0/m2repository/com/github/pedroSG94/RootEncoder/library/2.7.5/library-2.7.5.pom
[ERROR] [GRADLE]      Required by:
[ERROR] [GRADLE]          project ':app' > ti:twitch:1.0.0
[ERROR] [GRADLE]
[ERROR] [GRADLE] * Try:
[ERROR] [GRADLE] > Run with --stacktrace option to get the stack trace.
[ERROR] [GRADLE] > Run with --info or --debug option to get more log output.
[ERROR] [GRADLE] > Run with --scan to get full insights from a Build Scan (powered by Develocity).
[ERROR] [GRADLE] > Get more help at https://help.gradle.org.
[ERROR] [GRADLE]
[ERROR] [GRADLE] BUILD FAILED in 1s
```

**Fix:**
This PR will automatically gather the repos from modules and add them during the build process.

You can add `<merge-module-maven-repositories>false</merge-module-maven-repositories>` to your `<android>` tiapp.xml node to disable that for security reasons. I've kept it opt-out because the benefits of not editing a build.gradle file when you add a module is easier for most people (nobody reads the module README files :smile: ).

This also helps when you build the `example/app.js` in your modules and you simply can run `ti build - android` without adding another example build.gradle file.

**Test**
Checkout https://github.com/m1ga/ti.twitch and go to the android folder and run `ti build -p android`. This will compile the module + the demo app. Without this PR it will fail. With `ti build -p android --sdk 14.0.0` it will start the app.