### PR TITLE
feat(android): expose Ti.UI.TEXT_STYLE_* constants for cross-platform parity

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -154,6 +154,30 @@ public class UIModule extends KrollModule implements TiApplication.Configuration
 	@Kroll.constant
 	public static final String AUTOFILL_TYPE_CARD_EXPIRATION_YEAR = View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_YEAR;
 
+	// Text style constants (mirroring iOS UIFontTextStyle string values)
+	@Kroll.constant
+	public static final String TEXT_STYLE_HEADLINE = "UIFontTextStyleHeadline";
+	@Kroll.constant
+	public static final String TEXT_STYLE_SUBHEADLINE = "UIFontTextStyleSubheadline";
+	@Kroll.constant
+	public static final String TEXT_STYLE_BODY = "UIFontTextStyleBody";
+	@Kroll.constant
+	public static final String TEXT_STYLE_FOOTNOTE = "UIFontTextStyleFootnote";
+	@Kroll.constant
+	public static final String TEXT_STYLE_CAPTION1 = "UIFontTextStyleCaption1";
+	@Kroll.constant
+	public static final String TEXT_STYLE_CAPTION2 = "UIFontTextStyleCaption2";
+	@Kroll.constant
+	public static final String TEXT_STYLE_CALLOUT = "UIFontTextStyleCallout";
+	@Kroll.constant
+	public static final String TEXT_STYLE_TITLE1 = "UIFontTextStyleTitle1";
+	@Kroll.constant
+	public static final String TEXT_STYLE_TITLE2 = "UIFontTextStyleTitle2";
+	@Kroll.constant
+	public static final String TEXT_STYLE_TITLE3 = "UIFontTextStyleTitle3";
+	@Kroll.constant
+	public static final String TEXT_STYLE_LARGE_TITLE = "UIFontTextStyleLargeTitle";
+
 	@Kroll.constant
 	public static final int BLEND_MODE_NORMAL = 0;
 	@Kroll.constant

--- a/tests/Resources/ti.ui.constants.test.js
+++ b/tests/Resources/ti.ui.constants.test.js
@@ -20,7 +20,7 @@ describe('Titanium.UI', function () {
 		should(Ti.UI).have.a.constant('AUTOFILL_TYPE_ONE_TIME_CODE').which.is.a.String();
 	});
 
-	it.androidMissing('TEXT_STYLE_* constants', function () {
+	it('TEXT_STYLE_* constants', function () {
 		should(Ti.UI.TEXT_STYLE_HEADLINE).be.a.String();
 		should(Ti.UI.TEXT_STYLE_SUBHEADLINE).be.a.String();
 		should(Ti.UI.TEXT_STYLE_BODY).be.a.String();


### PR DESCRIPTION
Adds the `Ti.UI.TEXT_STYLE_*` constants on Android (mirroring the iOS `UIFontTextStyle` string values) for cross-platform API parity, and enables the corresponding test on Android.

Split out from #14524.