### PR TITLE
fix(android): webview safe-area-inset fix

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -7,6 +7,7 @@
 package ti.modules.titanium.ui.widget.webview;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.FeatureInfo;
 import android.graphics.Color;
@@ -21,6 +22,8 @@ import android.view.ViewParent;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import androidx.annotation.StringRes;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -290,6 +293,19 @@ public class TiUIWebView extends TiUIView
 			// silence unnecessary internal logs...
 		}
 		webView.setVerticalScrollbarOverlay(true);
+
+		// Chromium derives env(safe-area-inset-*) from the window insets this view receives,
+		// regardless of where the view sits on screen. Unless the window extends into the safe
+		// area, TiEdgeToEdgeHelper already keeps content clear of the system bars and display
+		// cutout, so the page would otherwise pad itself a second time.
+		boolean extendSafeArea = false;
+		Intent intent = (proxy.getActivity() != null) ? proxy.getActivity().getIntent() : null;
+		if (intent != null) {
+			extendSafeArea = intent.getBooleanExtra(TiC.PROPERTY_EXTEND_SAFE_AREA, false);
+		}
+		if (!extendSafeArea) {
+			ViewCompat.setOnApplyWindowInsetsListener(webView, (v, insets) -> WindowInsetsCompat.CONSUMED);
+		}
 
 		boolean multipleWindows = TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_MULTIPLE_WINDOWS), false);
 		WebSettings settings = webView.getSettings();


### PR DESCRIPTION
In a normal website you can use CSS `env(safe-area-inset-top)` to compensate for the edge-to-edge area on top. But our webview is not checking if it is in `extendSafeArea:true` mode or not and it will apply the CSS safe area padding even if it is `extendSafeArea:false`. This will show up like this:

<img width="373" height="274" alt="Screenshot_20260825-132224" src="https://github.com/user-attachments/assets/5efa5da1-7647-4753-9c3f-9e8ffec63d70" />

With this PR it will automatically use `WindowInsetsCompat.CONSUMED` which sets that CSS env to 0:

<img width="286" height="274" alt="Screenshot_20260825-132408" src="https://github.com/user-attachments/assets/5ee0001e-566a-4e2d-8c2c-01b42d9bcd46" />

and when you run it with `extendSafeArea:true` it will use the correct padding:

<img width="286" height="274" alt="Screenshot_20260825-132432" src="https://github.com/user-attachments/assets/db9eeb55-b01c-48da-b3b9-9ad41bc65750" />


**Test:**

```js
var win = Ti.UI.createWindow({
  theme:"Theme.Titanium.DayNight.NoTitleBar",
  // extendSafeArea: true
});
var web = Ti.UI.createWebView({
  url: "https://player.autopod.xyz/1417040"
})
win.add(web);
win.open();
```

Apps with existing webviews e.g. for graphs look the same as before:
<img width="640" height="202" alt="Screenshot_20260825-132522" src="https://github.com/user-attachments/assets/7f72768a-6717-40f0-8164-47d8801db2a9" />

<img width="640" height="209" alt="Screenshot_20260825-132558" src="https://github.com/user-attachments/assets/a06d2be5-9eb0-4055-992f-bba2a028f7f3" />

