### PR TITLE
fix(apidoc): correct invalid YAML in Geolocation.yml

### DIFF
--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -754,7 +754,7 @@ properties:
         See <Titanium.Geolocation.Android> for details on using manual mode.
     type: Number
     constants: [Titanium.Geolocation.ACCURACY_HIGH, Titanium.Geolocation.ACCURACY_BEST_FOR_NAVIGATION, Titanium.Geolocation.ACCURACY_LOW, Titanium.Geolocation.ACCURACY_BEST, Titanium.Geolocation.ACCURACY_NEAREST_TEN_METERS,
-    Titanium.Geolocation.ACCURACY_HUNDRED_METERS, Titanium.Geolocation.ACCURACY_KILOMETER, Titanium.Geolocation.ACCURACY_THREE_KILOMETERS, Titanium.Geolocation.ACCURACY_REDUCED]
+        Titanium.Geolocation.ACCURACY_HUNDRED_METERS, Titanium.Geolocation.ACCURACY_KILOMETER, Titanium.Geolocation.ACCURACY_THREE_KILOMETERS, Titanium.Geolocation.ACCURACY_REDUCED]
 
   - name: distanceFilter
     summary: The minimum change of position (in meters) before a 'location' event is fired.


### PR DESCRIPTION
`Titanium.Geolocation` is **currently missing from the API reference** because its apidoc file is not valid YAML.

The `accuracy` property's `constants` flow sequence continues onto a second line indented to the same level as its key:

```yaml
    constants: [Titanium.Geolocation.ACCURACY_HIGH, …, Titanium.Geolocation.ACCURACY_NEAREST_TEN_METERS,
    Titanium.Geolocation.ACCURACY_HUNDRED_METERS, …, Titanium.Geolocation.ACCURACY_REDUCED]
```

A flow sequence continuing inside a block mapping has to be indented **deeper** than its key. `js-yaml` 3 — which `titanium-docgen` uses — accepts it anyway, which is why this has gone unnoticed. Spec-compliant parsers reject the entire document, so the type vanishes silently rather than erroring.

### Verified

Parsing `apidoc/` with a spec-compliant parser before and after:

```
before: 417 types, 2 problems
after : 418 types, 1 problem      ← Titanium.Geolocation recovered
```

All nine constants survive with identical values. This is an indentation change on one line; no content is altered.

### Note

The remaining problem is unrelated and not addressed here: `showParams` is declared as two different pseudo-types, in `Titanium/UI/OptionDialog.yml` and `Titanium/Android/QuickSettingsService.yml`. Pseudo-types are not namespaced, so the current docs collide them into a single `structs/showparams.md` page — one of those dictionaries is published under the other's description. Worth its own issue.

Found while porting docgen for the [titaniumsdk.com rewrite](https://github.com/tidev/titanium-www).

🤖 Generated with [Claude Code](https://claude.com/claude-code)