### PR TITLE
fix(apidoc): namespace the two colliding showParams pseudo-types

### DIFF
--- a/apidoc/Titanium/Android/QuickSettingsService.yml
+++ b/apidoc/Titanium/Android/QuickSettingsService.yml
@@ -144,7 +144,7 @@ methods:
       If you pass both - only `message` will be shown.
     parameters:
       - name: options
-        type: showParams
+        type: QuickSettingsServiceShowParams
         summary: Dictionary containing the options for the dialog.
 
   - name: startActivityAndCollapse
@@ -237,7 +237,7 @@ examples:
         </ti:app>
         ```
 ---
-name: showParams
+name: QuickSettingsServiceShowParams
 summary: Dictionary of options for the <Titanium.Android.QuickSettingsService.showDialog> method.
 
 properties:

--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -118,7 +118,7 @@ methods:
       - name: params
         # FIXME: I think this is used on iOS, not just iPad
         summary: Argument containing parameters for this method. Only used on iPad.
-        type: showParams
+        type: OptionDialogShowParams
         optional: true
 
   - name: hide
@@ -371,7 +371,7 @@ properties:
     type: Boolean
 
 ---
-name: showParams
+name: OptionDialogShowParams
 summary: Dictionary of options for the <Titanium.UI.OptionDialog.show> method.
 platforms: [ipad, macos]
 


### PR DESCRIPTION
`showParams` is declared **twice, as two unrelated dictionaries**:

| File | Documents |
| --- | --- |
| `Titanium/UI/OptionDialog.yml` | options for `Titanium.UI.OptionDialog.show` |
| `Titanium/Android/QuickSettingsService.yml` | options for `Titanium.Android.QuickSettingsService.showDialog` |

Pseudo-types are not namespaced, so the generated docs collide them into a single `docs/api/structs/showparams.md`. **One of these dictionaries is currently published on the live site under the other's description** — whichever the generator processed last wins.

### The fix follows existing convention

`Titanium/UI/iOS/MenuPopup.yml` already does exactly this:

```yaml
name: MenuPopupShowParams          # declaration
type: MenuPopupShowParams          # reference
```

34 of the 178 pseudo-types in `apidoc/` prefix their owning type's short name in concatenated PascalCase — `CollatorOptions`, `OSUserInfo`, `UtilInspectOptions`, `DateTimeFormatOptions`. So:

- `showParams` → `OptionDialogShowParams`
- `showParams` → `QuickSettingsServiceShowParams`

### Scope

This is the **only** name collision among all 178 pseudo-types. Each rename touches the declaration and its single `type:` reference, both inside the same file, so nothing outside these two files changes. Verified: no other reference to `showParams` exists anywhere in the repo.

Parsing `apidoc/` before and after: the duplicate-name problem disappears and the previously-dropped type is recovered, 417 → 418.

### Note

This changes two generated page URLs — `structs/showparams.md` becomes `structs/optiondialogshowparams.md` and `structs/quicksettingsserviceshowparams.md`. The old URL is currently serving the wrong content for one of the two, so there is nothing correct being lost.

Independent of #14562, which fixes unrelated invalid YAML in `Geolocation.yml`. Both found while porting docgen for the [titaniumsdk.com rewrite](https://github.com/tidev/titanium-www).

🤖 Generated with [Claude Code](https://claude.com/claude-code)