### PR TITLE
refactor(cli): modernize the project command

### DIFF
--- a/cli/commands/project.js
+++ b/cli/commands/project.js
@@ -5,10 +5,15 @@
  * See the LICENSE file for more information.
  */
 
-import path from 'node:path';
+import { join } from 'node:path';
 import ti from 'node-titanium-sdk';
 import appc from 'node-appc';
 import { loadPlugins } from '../lib/load-plugins.js';
+import { commonOptions } from '../lib/common-options.js';
+import { validateProjectDir } from '../lib/validate-project-dir.js';
+import { platformAliases, resolvePlatform } from '../lib/resolve-platform.js';
+import { existsSync } from 'node:fs';
+import { sdkManifest } from '../lib/sdk-manifest.js';
 
 export const cliVersion = '>=9.1.0';
 export const desc = 'get and set tiapp.xml settings';
@@ -40,7 +45,7 @@ export function config(logger, config) {
 				desc: 'the name of the project template to use',
 				default: 'default'
 			}
-		}, ti.commonOptions(logger, config)),
+		}, commonOptions(logger, config)),
 		args: [
 			{
 				name: 'key',
@@ -55,7 +60,7 @@ export function config(logger, config) {
 }
 
 export async function validate(logger, config, cli) {
-	ti.validateProjectDir(logger, cli, cli.argv, 'project-dir');
+	validateProjectDir(logger, cli, cli.argv, 'project-dir');
 
 	// Validate the key, if it exists
 	if (cli.argv._.length > 0) {
@@ -69,209 +74,204 @@ export async function validate(logger, config, cli) {
 	await loadPlugins(null, config, cli, cli.argv.output !== 'report' || cli.argv._.length, false);
 }
 
-export function run(logger, config, cli, finished) {
-	var projectDir = cli.argv['project-dir'],
-		tiappPath = path.join(projectDir, 'tiapp.xml'),
-		tiapp = new ti.tiappxml(tiappPath),
-		output = cli.argv.output,
-		key,
-		value,
-		result = {},
-		args = cli.argv._,
-		n,
-		p,
-		maxlen,
-		sdkPath = cli.sdk.path,
-		templateDir,
-		propsList = [ 'sdk-version', 'id', 'name', 'version', 'publisher', 'url', 'description', 'copyright', 'icon', 'guid' ],
-		deploymentTargets = tiapp['deployment-targets'];
+const propsList = ['sdk-version', 'id', 'name', 'version', 'publisher', 'url', 'description', 'copyright', 'icon', 'guid'];
 
-	args.length === 0 && output === 'report' && logger.banner();
+function printProjectInfo(logger, cli, tiapp) {
+	const { output } = cli.argv;
 
-	switch (args.length) {
-		case 0:
-			if (output === 'json') {
+	if (output === 'json') {
+		// Store the deployment targets
+		const result = new ti.tiappxml();
+		result['deployment-targets'] = { ...tiapp['deployment-targets'] };
 
-				// Store the deployment targets
-				result =  new ti.tiappxml();
-				result['deployment-targets'] = {};
-				for (p in deploymentTargets) {
-					result['deployment-targets'][p] = deploymentTargets[p];
-				}
+		// Copy all of the other properties in and print the results
+		for (const key of propsList) {
+			result[key] = tiapp[key];
+		}
+		logger.log(result.toString('pretty-json'));
+		return;
+	}
 
-				// Copy all of the other properties in and print the results
-				propsList.forEach(function (p) {
-					result[p] = tiapp[p];
-				});
-				logger.log(result.toString('pretty-json'));
+	// Print the deployment targets
+	const deploymentTargets = tiapp['deployment-targets'] || {};
+	logger.log('Deployment Targets:');
+	let maxlen = Object.keys(deploymentTargets).reduce((a, b) => Math.max(a, b.length), 0);
+	for (const target of Object.keys(deploymentTargets)) {
+		logger.log(`  ${target.padEnd(maxlen)} = ${String(deploymentTargets[target]).cyan}`);
+	}
+	logger.log();
 
-			} else {
+	// Print the other properties
+	logger.log('Project Properties:');
+	maxlen = propsList.reduce((a, b) => Math.max(a, b.length), 0);
+	for (const key of propsList) {
+		logger.log(`  ${key.padEnd(maxlen)} = ${String(tiapp[key] || 'not specified').cyan}`);
+	}
+	logger.log();
+}
 
-				// Print the deployment targets
-				logger.log('Deployment Targets:');
-				maxlen = Object.keys(deploymentTargets).reduce(function (a, b) {
-					return Math.max(a, b.length);
-				}, 0);
-				for (p in tiapp['deployment-targets']) {
-					logger.log(`  ${appc.string.rpad(p, maxlen)} = ${(deploymentTargets[p] + '').cyan}`);
-				}
-				logger.log();
+function getProjectKey(logger, cli, tiapp) {
+	const { output } = cli.argv;
+	const key = cli.argv._[0];
 
-				// Print the other properties
-				logger.log('Project Properties:');
-				maxlen = propsList.reduce(function (a, b) {
-					return Math.max(a, b.length);
-				}, 0);
-				propsList.forEach(function (key) {
-					logger.log(`  ${appc.string.rpad(key, maxlen)} = ${String(tiapp[key] || 'not specified').cyan}`);
-				});
-				logger.log();
+	if (key === 'deployment-targets') {
+		const deploymentTargets = tiapp['deployment-targets'] || {};
+		if (output === 'json') {
+			logger.log(JSON.stringify({
+				'deployment-targets': deploymentTargets
+			}));
+		} else if (output === 'text') {
+			logger.log(Object.keys(deploymentTargets).map(target => `${target}=${deploymentTargets[target]}`).join(','));
+		} else {
+			logger.log('Deployment Targets:');
+			const maxlen = Object.keys(deploymentTargets).reduce((a, b) => Math.max(a, b.length), 0);
+			logger.log(Object.keys(deploymentTargets).map(target => `  ${target.padEnd(maxlen)} = ${String(deploymentTargets[target]).cyan}`).join('\n'));
+			logger.log();
+		}
+		return;
+	}
+
+	if (propsList.includes(key)) {
+		if (output === 'json') {
+			logger.log(JSON.stringify(tiapp[key] || ''));
+		} else {
+			logger.log(tiapp[key]);
+		}
+		return;
+	}
+
+	if (output === 'json') {
+		logger.log('null');
+	} else {
+		logger.error(`${key} is not a valid entry name\n`);
+	}
+	process.exit(1);
+}
+
+function setProjectKey(logger, cli, tiapp) {
+	const [key, value] = cli.argv._;
+	const projectDir = cli.argv['project-dir'];
+	const sdkPath = cli.sdk.path;
+
+	switch (key) {
+		case 'deployment-targets':
+			const result = {};
+			const deploymentTargets = value?.split(',') || [];
+
+			for (const platform of sdkManifest.platforms) {
+				result[platform] = false;
 			}
-			break;
 
-		case 1:
-			key = args[0];
-			if (key === 'deployment-targets') {
-				if (output === 'json') {
-					result = {
-						'deployment-targets': {}
-					};
-					for (p in deploymentTargets) {
-						result['deployment-targets'][p] = deploymentTargets[p];
-					}
-					logger.log(JSON.stringify(result));
-				} else if (output === 'text') {
-					result = [];
-					for (p in deploymentTargets) {
-						result.push(p + '=' + deploymentTargets[p]);
-					}
-					logger.log(result.join(','));
-				} else {
-					// Print the deployment targets
-					logger.log('Deployment Targets:');
-					maxlen = Object.keys(deploymentTargets).reduce(function (a, b) {
-						return Math.max(a, b.length);
-					}, 0);
-					for (p in tiapp['deployment-targets']) {
-						logger.log(`  ${appc.string.rpad(p, maxlen)} = ${(deploymentTargets[p] + '').cyan}`);
+			for (const [alias, platform] of Object.entries(platformAliases)) {
+				if (alias !== 'ios' && sdkManifest.platforms.includes(platform)) {
+					result[alias] = false;
+				}
+			}
+
+			// Validate the platforms and override the tiapp.xml setting to true
+			for (const target of deploymentTargets) {
+				if (!Object.hasOwn(result, target)) {
+					logger.error(`Unsupported deployment target "${target}"\n`);
+					logger.log('Available deployment targets are:');
+					for (const target of Object.keys(result).sort()) {
+						logger.log(`    ${target.cyan}`);
 					}
 					logger.log();
+					process.exit(1);
 				}
-			} else if (~propsList.indexOf(key)) {
-				if (output === 'json') {
-					logger.log(JSON.stringify(tiapp[key] || ''));
-				} else {
-					logger.log(tiapp[key]);
-				}
-			} else {
-				if (output === 'json') {
-					logger.log('null');
-				} else {
-					logger.error(`${key} is not a valid entry name\n`);
-				}
+			}
+
+			for (const target of deploymentTargets) {
+				result[target] = true;
+			}
+
+			// Update the tiapp.xml
+			tiapp['deployment-targets'] = result;
+
+			// Non-destructively copy over files from <sdk>/templates/app/<template>/template
+			const templateDir = join(sdkPath, 'templates', 'app', cli.argv.template, 'template');
+			if (!existsSync(templateDir)) {
+				logger.error(`Unknown project template ${cli.argv.template}\n`);
 				process.exit(1);
 			}
-			break;
 
-		case 2:
-			key = args[0];
-			switch (key) {
-				case 'deployment-targets':
+			let numCopied = appc.fs.nonDestructiveCopyDirSyncRecursive(templateDir, projectDir, {
+				logger: logger.log,
+				ignoreHiddenFiles: true
+			});
 
-					// Get list of platforms from ti manifest and set to false (default value)
-					result = {};
-
-					// add ipad and blackberry to list of platforms
-					[ 'ipad', 'blackberry' ].concat(ti.availablePlatforms).forEach(function (p) {
-						result[p] = false;
-					});
-
-					// Validate the platforms and override the tiapp.xml setting to true
-					value = args[1].split(',');
-					value.forEach(function (p) {
-						if (!Object.prototype.hasOwnProperty.call(result, p)) {
-							logger.error(`Unsupported deployment target "${p}"\n`);
-							logger.log('Available deployment targets are:');
-							Object.keys(result).sort().forEach(function (p) {
-								logger.log('    ' + p.cyan);
-							});
-							logger.log();
-							process.exit(1);
-						}
-					});
-
-					for (p = 0; p < value.length; p++) {
-						result[value[p]] = true;
-					}
-
-					// Update the tiapp.xml
-					tiapp['deployment-targets'] = result;
-
-					// Non-destructively copy over files from <sdk>/templates/app/<template>/template
-					templateDir = path.join(sdkPath, 'templates', 'app', cli.argv.template, 'template');
-					if (!appc.fs.exists(templateDir)) {
-						logger.error(`Unknown project template ${cli.argv.template}\n`);
-						process.exit(1);
-					}
-
-					n = appc.fs.nonDestructiveCopyDirSyncRecursive(templateDir, projectDir, {
+			// Non-destructively copy over files from <sdk>/<each platform>/templates/app/<template>/
+			for (const target of deploymentTargets) {
+				const templateDir = join(sdkPath, resolvePlatform(target), 'templates', 'app', cli.argv.template, 'template');
+				if (existsSync(templateDir)) {
+					numCopied += appc.fs.nonDestructiveCopyDirSyncRecursive(templateDir, projectDir, {
 						logger: logger.log,
 						ignoreHiddenFiles: true
 					});
-
-					// Non-destructively copy over files from <sdk>/<each platform>/templates/app/<template>/
-					for (p = 0; p < value.length; p++) {
-						if (value[p]) {
-							templateDir = path.join(sdkPath, ti.resolvePlatform(value[p]), 'templates', 'app', cli.argv.template, 'template');
-							if (appc.fs.exists(templateDir)) {
-								n += appc.fs.nonDestructiveCopyDirSyncRecursive(templateDir, projectDir, {
-									logger: logger.log,
-									ignoreHiddenFiles: true
-								});
-							}
-						}
-					}
-					value = value.join(', ');
-					n && logger.log();
-					break;
-				case 'sdk-version':
-					value = args[1];
-					if (value === 'latest') {
-						value = Object.keys(cli.env.sdks).sort().reverse()[0];
-					}
-					if (!(value in cli.env.sdks)) {
-						logger.error(`Unknown SDK ${value}\n`);
-						process.exit(1);
-					}
-					tiapp['sdk-version'] = value;
-					break;
-				case 'id':
-					value = args[1];
-					if (!/^([a-z_]{1}[a-z0-9_]*(\.[a-z_]{1}[a-z0-9_]*)*)$/.test(value)) {
-						logger.error(`Invalid project ID ${value}\n`);
-						process.exit(1);
-					}
-					tiapp['id'] = value;
-					break;
-				case 'name':
-				case 'version':
-				case 'publisher':
-				case 'url':
-				case 'description':
-				case 'copyright':
-				case 'icon':
-				case 'guid':
-					tiapp[key] = value = args[1] || '';
-					break;
-				default:
-					logger.error('Invalid tiapp.xml key "' + key + '"');
-					break;
+				}
 			}
-			logger.log('tiapp.xml saving is currently not supported');
-			// logger.log(`${(key + '').cyan} was successfully set to ${(value + '').cyan}\n`);
-			// tiapp.save(tiappPath);
+			if (numCopied > 0) {
+				logger.log();
+			}
+			break;
+
+		case 'sdk-version':
+			let sdkVersion = value;
+			if (sdkVersion === 'latest') {
+				sdkVersion = Object.keys(cli.env.sdks).sort().reverse()[0];
+			}
+			if (!Object.hasOwn(cli.env.sdks, sdkVersion)) {
+				logger.error(`Unknown SDK ${sdkVersion}\n`);
+				process.exit(1);
+			}
+			tiapp['sdk-version'] = sdkVersion;
+			break;
+		case 'id':
+			const projectId = value || '';
+			if (!/^([a-z_]{1}[a-z0-9_]*(\.[a-z_]{1}[a-z0-9_]*)*)$/.test(projectId)) {
+				logger.error(`Invalid project ID ${projectId}\n`);
+				process.exit(1);
+			}
+			tiapp['id'] = projectId;
+			break;
+		case 'name':
+		case 'version':
+		case 'publisher':
+		case 'url':
+		case 'description':
+		case 'copyright':
+		case 'icon':
+		case 'guid':
+			tiapp[key] = value || '';
+			break;
+		default:
+			logger.error(`Invalid tiapp.xml key "${key}"`);
 			break;
 	}
+	logger.log('tiapp.xml saving is currently not supported');
+	// logger.log(`${(key + '').cyan} was successfully set to ${(value + '').cyan}\n`);
+	// tiapp.save(tiappPath);
+}
 
-	finished();
+export async function run(logger, _config, cli) {
+	const {
+		output,
+		_: args
+	} = cli.argv;
+	const tiapp = new ti.tiappxml(join(cli.argv['project-dir'], 'tiapp.xml'));
+
+	if (args.length === 0 && output === 'report') {
+		logger.banner();
+	}
+
+	if (args.length === 0) {
+		printProjectInfo(logger, cli, tiapp);
+	} else if (args.length === 1) {
+		getProjectKey(logger, cli, tiapp);
+	} else if (args.length === 2) {
+		setProjectKey(logger, cli, tiapp);
+	} else {
+		logger.error(`Invalid number of arguments\n`);
+		process.exit(1);
+	}
 }

--- a/cli/lib/common-options.js
+++ b/cli/lib/common-options.js
@@ -1,0 +1,16 @@
+export function commonOptions(logger, config) {
+	return {
+		'log-level': {
+			abbr: 'l',
+			callback(value) {
+				if (Object.hasOwn(logger.levels, value)) {
+					logger.setLevel(value);
+				}
+			},
+			desc: 'minimum logging level',
+			default: config.cli.logLevel || 'trace',
+			hint: 'level',
+			values: logger.getLevels()
+		}
+	};
+}

--- a/cli/lib/validate-project-dir.js
+++ b/cli/lib/validate-project-dir.js
@@ -1,0 +1,33 @@
+import ti from 'node-titanium-sdk';
+import appc from 'node-appc';
+import { dirname, join, sep } from 'node:path';
+import { existsSync } from 'node:fs';
+
+export function validateProjectDir(logger, cli, argv, name) {
+	const dir = argv[name] || (process.env.SOURCE_ROOT ? join(process.env.SOURCE_ROOT, '..', '..') : '.');
+	let projectDir = argv[name] = appc.fs.resolvePath(dir);
+
+	if (!existsSync(projectDir)) {
+		logger.banner();
+		logger.error('Project directory does not exist\n');
+		process.exit(1);
+	}
+
+	let tiapp = join(projectDir, 'tiapp.xml');
+	while (!existsSync(tiapp) && tiapp.split(sep).length > 2) {
+		projectDir = argv[name] = dirname(projectDir);
+		tiapp = join(projectDir, 'tiapp.xml');
+	}
+
+	if (tiapp.split(sep).length === 2) {
+		logger.banner();
+		logger.error(`Invalid project directory "${dir}"\n`);
+		if (dir === '.') {
+			logger.log(`Use the "--project-dir" option to specify the project's directory\n`);
+		}
+		process.exit(1);
+	}
+
+	// load the tiapp.xml
+	cli.tiapp = new ti.tiappxml(join(projectDir, 'tiapp.xml'));
+}

--- a/cli/tests/test-project-run.js
+++ b/cli/tests/test-project-run.js
@@ -1,0 +1,316 @@
+import { expect } from 'chai';
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import ti from 'node-titanium-sdk';
+import { run } from '../commands/project.js';
+
+// The Titanium CLI installs the color getters on String, Number *and* Boolean
+// before running an SDK command (see `assignColors()` in titanium/src/cli.js).
+// Deployment target values parse as booleans, so without the Boolean prototype
+// these tests would report a styling bug that does not exist at runtime.
+const COLOR_PROPS = [ 'blue', 'bold', 'cyan', 'gray', 'green', 'grey', 'magenta', 'red', 'yellow' ];
+
+function assignColors() {
+	const descriptors = Object.fromEntries(
+		COLOR_PROPS.map(name => [ name, { get() { return `${this}`; }, configurable: true } ])
+	);
+	for (const proto of [ String.prototype, Number.prototype, Boolean.prototype ]) {
+		Object.defineProperties(proto, descriptors);
+	}
+}
+
+function removeColors() {
+	for (const proto of [ String.prototype, Number.prototype, Boolean.prototype ]) {
+		for (const name of COLOR_PROPS) {
+			delete proto[name];
+		}
+	}
+}
+
+const TIAPP = `<?xml version="1.0" encoding="UTF-8"?>
+<ti:app xmlns:ti="http://ti.appcelerator.org">
+	<id>com.example.app</id>
+	<name>Demo</name>
+	<version>1.0.0</version>
+	<guid>abc-123</guid>
+	<sdk-version>14.0.0</sdk-version>
+	<deployment-targets>
+		<target device="android">true</target>
+		<target device="iphone">true</target>
+		<target device="ipad">false</target>
+	</deployment-targets>
+	<property name="secret" type="string">hunter2</property>
+	<modules>
+		<module platform="android">ti.foo</module>
+	</modules>
+</ti:app>
+`;
+
+/**
+ * Mirrors the device family derivation in iphone/cli/commands/_build.js so the
+ * tests assert the map the build actually consumes, not just the keys written.
+ *
+ * @param {Object} targets - The tiapp.xml `deployment-targets`
+ * @returns {String}
+ */
+function deviceFamily(targets) {
+	if (targets.ipad && !targets.iphone) {
+		return 'ipad';
+	}
+	if (targets.iphone && !targets.ipad) {
+		return 'iphone';
+	}
+	return 'universal';
+}
+
+describe('project run()', () => {
+	let projectDir;
+	let sdkDir;
+	let output;
+	let logger;
+	let realExit;
+	let realTiappxml;
+	let tiapp;
+
+	before(assignColors);
+	after(removeColors);
+
+	beforeEach(() => {
+		projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ti-project-'));
+		fs.writeFileSync(path.join(projectDir, 'tiapp.xml'), TIAPP);
+
+		// a fake SDK with a shared template and an iphone-specific one, so the
+		// ipad -> iphone alias resolution is observable
+		sdkDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ti-sdk-'));
+		fs.outputFileSync(path.join(sdkDir, 'templates', 'app', 'default', 'template', 'base.txt'), 'base');
+		fs.outputFileSync(path.join(sdkDir, 'iphone', 'templates', 'app', 'default', 'template', 'ios.txt'), 'ios');
+		fs.outputFileSync(path.join(sdkDir, 'android', 'templates', 'app', 'default', 'template', 'droid.txt'), 'droid');
+
+		output = [];
+		logger = {
+			log: (...args) => output.push(args.length ? args.join(' ') : ''),
+			error: (...args) => output.push(`ERROR: ${args.join(' ')}`),
+			banner: () => output.push('<banner>')
+		};
+
+		// run() builds its own tiappxml, so capture the instance it mutates
+		realTiappxml = ti.tiappxml;
+		tiapp = null;
+		ti.tiappxml = function (file) {
+			tiapp = new realTiappxml(file);
+			return tiapp;
+		};
+
+		realExit = process.exit;
+		process.exit = code => {
+			const err = new Error(`process.exit(${code})`);
+			err.exitCode = code;
+			throw err;
+		};
+	});
+
+	afterEach(() => {
+		process.exit = realExit;
+		ti.tiappxml = realTiappxml;
+		fs.removeSync(projectDir);
+		fs.removeSync(sdkDir);
+	});
+
+	/**
+	 * @param {String[]} args - The positional args
+	 * @param {Object} [argv] - Extra argv overrides
+	 * @returns {Promise<Object>} The captured exit error, if any
+	 */
+	async function exec(args, argv = {}) {
+		const cli = {
+			argv: {
+				output: 'report',
+				'project-dir': projectDir,
+				template: 'default',
+				_: args,
+				...argv
+			},
+			sdk: { path: sdkDir },
+			env: { sdks: { '14.0.0': {}, '13.0.0': {} } }
+		};
+		try {
+			await run(logger, {}, cli);
+		} catch (err) {
+			if (err.exitCode === undefined) {
+				throw err;
+			}
+			return err;
+		}
+		return null;
+	}
+
+	const text = () => output.join('\n');
+
+	describe('reporting', () => {
+		it('prints deployment target values rather than a styled non-string', async () => {
+			await exec([]);
+
+			const start = output.indexOf('Deployment Targets:') + 1;
+			expect(output.slice(start, start + 3)).to.deep.equal([
+				'  android = true',
+				'  iphone  = true',
+				'  ipad    = false'
+			]);
+			expect(text()).to.not.include('undefined');
+		});
+
+		it('prints every known project property', async () => {
+			await exec([]);
+
+			expect(text()).to.match(/^ {2}name {8}= Demo$/m);
+			expect(text()).to.match(/^ {2}publisher {3}= not specified$/m);
+		});
+
+		it('limits -o json to the deployment targets and known properties', async () => {
+			await exec([], { output: 'json' });
+
+			const result = JSON.parse(text());
+			expect(Object.keys(result)).to.deep.equal([
+				'deployment-targets', 'sdk-version', 'id', 'name', 'version', 'guid'
+			]);
+			// tiapp.xml sections outside the whitelist must not leak into the output
+			expect(result).to.not.have.property('properties');
+			expect(result).to.not.have.property('modules');
+			expect(text()).to.not.include('hunter2');
+		});
+	});
+
+	describe('getting a key', () => {
+		it('wraps deployment targets in -o json', async () => {
+			await exec([ 'deployment-targets' ], { output: 'json' });
+
+			expect(JSON.parse(text())).to.deep.equal({
+				'deployment-targets': { android: true, iphone: true, ipad: false }
+			});
+		});
+
+		it('joins deployment targets in -o text', async () => {
+			await exec([ 'deployment-targets' ], { output: 'text' });
+
+			expect(text()).to.equal('android=true,iphone=true,ipad=false');
+		});
+
+		it('prints a single property', async () => {
+			await exec([ 'name' ]);
+
+			expect(text()).to.equal('Demo');
+		});
+
+		it('exits non-zero for an unknown key', async () => {
+			const err = await exec([ 'bogus' ]);
+
+			expect(err.exitCode).to.equal(1);
+			expect(text()).to.include('bogus is not a valid entry name');
+		});
+	});
+
+	describe('setting deployment-targets', () => {
+		it('supports an iPhone-only app', async () => {
+			await exec([ 'deployment-targets', 'iphone' ]);
+
+			expect(tiapp['deployment-targets']).to.deep.equal({ android: false, iphone: true, ipad: false });
+			expect(deviceFamily(tiapp['deployment-targets'])).to.equal('iphone');
+		});
+
+		it('supports an iPad-only app', async () => {
+			await exec([ 'deployment-targets', 'ipad' ]);
+
+			expect(tiapp['deployment-targets']).to.deep.equal({ android: false, iphone: false, ipad: true });
+			expect(deviceFamily(tiapp['deployment-targets'])).to.equal('ipad');
+		});
+
+		it('supports a universal app', async () => {
+			await exec([ 'deployment-targets', 'iphone,ipad' ]);
+
+			expect(tiapp['deployment-targets']).to.deep.equal({ android: false, iphone: true, ipad: true });
+			expect(deviceFamily(tiapp['deployment-targets'])).to.equal('universal');
+		});
+
+		it('rejects "ios", which is a build platform and not a deployment target', async () => {
+			const err = await exec([ 'deployment-targets', 'ios' ]);
+
+			expect(err.exitCode).to.equal(1);
+			expect(text()).to.include('Unsupported deployment target "ios"');
+		});
+
+		it('rejects a retired platform and lists the supported ones', async () => {
+			const err = await exec([ 'deployment-targets', 'android,blackberry' ]);
+
+			expect(err.exitCode).to.equal(1);
+			expect(text()).to.include('Unsupported deployment target "blackberry"');
+			const listed = output.slice(output.indexOf('Available deployment targets are:') + 1)
+				.map(line => line.trim())
+				.filter(Boolean);
+			expect(listed).to.deep.equal([ 'android', 'ipad', 'iphone' ]);
+		});
+
+		it('copies the iphone template for an ipad target', async () => {
+			await exec([ 'deployment-targets', 'ipad' ]);
+
+			expect(fs.existsSync(path.join(projectDir, 'base.txt')), 'shared template').to.equal(true);
+			expect(fs.existsSync(path.join(projectDir, 'ios.txt')), 'iphone template via ipad alias').to.equal(true);
+			expect(fs.existsSync(path.join(projectDir, 'droid.txt')), 'android template').to.equal(false);
+		});
+
+		it('exits non-zero for an unknown template', async () => {
+			const err = await exec([ 'deployment-targets', 'android' ], { template: 'nope' });
+
+			expect(err.exitCode).to.equal(1);
+			expect(text()).to.include('Unknown project template nope');
+		});
+	});
+
+	describe('setting other keys', () => {
+		it('sets a simple string property', async () => {
+			await exec([ 'name', 'Renamed' ]);
+
+			expect(tiapp.name).to.equal('Renamed');
+		});
+
+		it('clears a simple string property when the value is empty', async () => {
+			await exec([ 'name', '' ]);
+
+			expect(tiapp.name).to.equal('');
+		});
+
+		it('resolves an sdk-version of "latest"', async () => {
+			await exec([ 'sdk-version', 'latest' ]);
+
+			expect(tiapp['sdk-version']).to.equal('14.0.0');
+		});
+
+		it('exits non-zero for an unknown sdk-version', async () => {
+			const err = await exec([ 'sdk-version', '99.0.0' ]);
+
+			expect(err.exitCode).to.equal(1);
+			expect(text()).to.include('Unknown SDK 99.0.0');
+		});
+
+		it('exits non-zero for an invalid project id', async () => {
+			const err = await exec([ 'id', 'Not A Valid Id' ]);
+
+			expect(err.exitCode).to.equal(1);
+			expect(text()).to.include('Invalid project ID');
+		});
+
+		it('reports an invalid key instead of writing it', async () => {
+			await exec([ 'nonsense', 'x' ]);
+
+			expect(text()).to.include('Invalid tiapp.xml key "nonsense"');
+			expect(tiapp).to.not.have.property('nonsense');
+		});
+	});
+
+	it('rejects more than two arguments', async () => {
+		const err = await exec([ 'name', 'a', 'b' ]);
+
+		expect(err.exitCode).to.equal(1);
+		expect(text()).to.include('Invalid number of arguments');
+	});
+});


### PR DESCRIPTION
Modernizes the `project` command and moves two more helpers out of `node-titanium-sdk`, continuing the CLI migration from #14556.

## What changed

**`cli/commands/project.js`**
- `run()` is now `async run(logger, config, cli)`, matching `build` and `clean`; the `finished` callback is gone.
- The `switch (args.length)` block is split into `printProjectInfo()`, `getProjectKey()` and `setProjectKey()`.
- `var` chain at the top of `run()` replaced with block-scoped locals; `path` → `join`, `appc.fs.exists` → `existsSync`, `appc.string.rpad` → `padEnd`, `~indexOf` → `includes`.

**New `cli/lib/` helpers**
- `commonOptions()` and `validateProjectDir()` ported from `node-titanium-sdk`. `create`, `build` and `clean` still use the `ti.*` versions, so both exist for now.

## Behavior changes

- **`blackberry` is no longer a valid deployment target.** Validation now seeds from `sdkManifest.platforms` plus the `ipad` alias from `resolve-platform.js`, giving `android`, `iphone`, `ipad` — the same key set `ti create` writes. `ios` remains rejected: it is a build platform that maps to a device family, never a `deployment-targets` entry.
- **More than two arguments is now an error.** Previously `ti project a b c` matched no `switch` case and silently did nothing.

## Tests

New `cli/tests/test-project-run.js`, 21 tests, picked up by `npm run test:cli`:

- `report` / `json` / `text` output for the full project and for a single key
- `-o json` stays limited to `deployment-targets` plus the known property list, so `properties`, `modules` and platform sections do not leak into the output
- deployment target validation: iPhone-only, iPad-only and universal all reachable; `ios` and `blackberry` rejected
- the `ipad` → `iphone` alias actually copies the iphone template
- assertions run the written map through the same device family derivation as `iphone/cli/commands/_build.js`, so a regression in the target keys shows up as a wrong device family rather than just a wrong dict

One harness note worth knowing for future CLI tests: the suite installs the color getters on `String`, `Number` **and** `Boolean` prototypes, mirroring `assignColors()` in `titanium/src/cli.js`. Deployment target values parse as booleans, so a test that only loads the `colors` package (which patches `String.prototype` alone) will report a styling bug that does not exist at runtime.

Each fix was mutation-tested by reverting it and confirming the suite fails.
