### PR TITLE
docs: resolve 23 broken cross-references

### DIFF
--- a/apidoc/Global/Intl/NumberFormat.yml
+++ b/apidoc/Global/Intl/NumberFormat.yml
@@ -216,7 +216,7 @@ properties:
 
       *    `'decimal'` Formats as a floating point value such as `'-1,234.5'`.
       *    `'currency'` Formats value as a currency such as `'$100'`.
-           You must also set the <Global.Intl.NumberFormat.NumberFormatOptions.currency> option
+           You must also set the <NumberFormatOptions.currency> option
            when using this style or else an exception will be thrown.
       *    `'percent'` Multiplies value by 100 and formats as a percentage.
            For example, a value of `1.0` will be formatted as `'100%'`.
@@ -237,7 +237,7 @@ properties:
     type: String
     summary: Set to the ISO 4217 currency code to use when formatting with the currency style.
     description: |
-      If the <Global.Intl.NumberFormat.NumberFormatOptions.style> option is set to `'currency'`,
+      If the <NumberFormatOptions.style> option is set to `'currency'`,
       then you must also set this `currency` option to an
       [ISO 4217](https://www.currency-iso.org/en/home/tables/table-a1.html) currency code
       such as `'USD'` for US dollars or `'EUR'` for euros.
@@ -247,7 +247,7 @@ properties:
     default: "symbol"
     summary: Indicates how the currency symbol or name should be shown.
     description: |
-      This option is only applicable if <Global.Intl.NumberFormat.NumberFormatOptions.style>
+      This option is only applicable if <NumberFormatOptions.style>
       is set to `'currency'`.
 
       This option can be set to one of the following:

--- a/apidoc/NodeJS/fs.yml
+++ b/apidoc/NodeJS/fs.yml
@@ -1510,7 +1510,7 @@ methods:
 ---
 name: fs.Dirent
 summary: |
-    A representation of a directory entry, which can be a file or a subdirectory within the directory, as returned by reading from an <fs.Dir>.
+    A representation of a directory entry, which can be a file or a subdirectory within the directory, as returned by <fs.readdir>.
     The directory entry is a combination of the file name and file type pairs.
 
     **NOTE:** Titanium does not currently implement this type.
@@ -1648,7 +1648,7 @@ properties:
 ---
 name: fs.rm.options
 # TODO: extends: fs.rmDir.options and add force property (but then I think new doc site won't show inherited properties nicely)
-summary: options for <fs.rm> and <fs.rmSync> methods
+summary: options for the <fs.rmSync> method
 since: '8.3.0'
 properties:
   - name: force
@@ -1680,7 +1680,7 @@ properties:
 
 ---
 name: fs.rmDir.options
-summary: options for <fs.rmDir> and <fs.rmDirSync> methods
+summary: options for the <fs.rmdir> method
 since: '8.3.0'
 properties:
   - name: maxRetries

--- a/apidoc/Titanium/Geolocation/Android/Android.yml
+++ b/apidoc/Titanium/Geolocation/Android/Android.yml
@@ -52,8 +52,8 @@ description: |
     <Titanium.Geolocation> module are ignored:
 
     *   [Geolocation.accuracy](Titanium.Geolocation.accuracy)
-    *   [Geolocation.frequency](Titanium.Geolocation.frequency)
-    *   [Geolocation.preferredProvider](Titanium.Geolocation.preferredProvider)
+    *   `Geolocation.frequency`
+    *   `Geolocation.preferredProvider`
 
     When `manualMode` is `false`, the `accuracy`, `frequency` and `preferredProvider`
     settings from <Titanium.Geolocation> are used to configure location updates.
@@ -168,7 +168,7 @@ properties:
         configured in this module.
         
         If `false`, location updates are configured using the  [accuracy](Titanium.Geolocation.accuracy),
-        [frequency](Titanium.Geolocation.frequency) and [preferredProvider](Titanium.Geolocation.preferredProvider)
+        `frequency` and `preferredProvider`
         properties in the <Titanium.Geolocation> module.
     type: Boolean
     default: false

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -804,6 +804,12 @@ properties:
     permission: read-only
     since: "7.5.0"
 
+  - name: AUDIO_STATE_WAITING_FOR_QUEUE
+    summary: Player is waiting for the audio queue to fill before starting.
+    type: Number
+    permission: read-only
+    since: "7.5.0"
+
   - name: VERTICAL_ALIGN_CENTER
     summary: Vertical align center
     type: Number
@@ -2170,7 +2176,7 @@ properties:
   - name: success
     summary: Function to call when the photo gallery is closed after a successful selection.
     description: |
-        If <Titanium.Media.allowMultiple> is `true`, then Callback<CameraMediaMultipleItemsType> will be invoked.
+        If <PhotoGalleryOptionsType.allowMultiple> is `true`, then Callback<CameraMediaMultipleItemsType> will be invoked.
         Otherwise Callback<CameraMediaItemType> will be invoked for single selection.
     type: [Callback<CameraMediaItemType>, Callback<CameraMediaMultipleItemsType>]
 
@@ -2253,7 +2259,7 @@ properties:
     summary: Specifies number of media item that can be selected.
     description: |
         Setting this property to zero allows you to select maximum number of media supported by system.
-        This will work only when <Titanium.Media.allowMultiple> is `true`.
+        This will work only when <PhotoGalleryOptionsType.allowMultiple> is `true`.
     type: Boolean
     platforms: [iphone, ipad]
     osver: {ios: {min: "14.0"}}
@@ -2268,7 +2274,7 @@ properties:
 
 ---
 name: CameraMediaMultipleItemsType
-summary: A media object from photo gallery when <Titanium.Media.allowMultiple> is `true`.
+summary: A media object from photo gallery when <PhotoGalleryOptionsType.allowMultiple> is `true`.
 extends: SuccessResponse
 properties:
   - name: images

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -368,7 +368,7 @@ properties:
         Set this parameter when authentication against NTLM domains along with the [username](Titanium.Network.HTTPClient.username)
         and [password](Titanium.Network.HTTPClient.password) properties.
         iOS supports NTLM authentication natively.
-        Android can be extended using the [addAuthFactory](Titanium.Network.HTTPClient.addAuthFactory) method.
+        Android supports Basic authentication only.
         Must be set before calling [open](Titanium.Network.HTTPClient.open).
     type: String
     default: Undefined

--- a/apidoc/Titanium/Network/TCPSocket.yml
+++ b/apidoc/Titanium/Network/TCPSocket.yml
@@ -74,7 +74,7 @@ events:
         type: Number
 properties:
   - name: hostName
-    summary: the host name to connect to.  Must be <Titanium.Network.INADDR_ANY> or an identifier for the local device in order to listen
+    summary: the host name to connect to.  Must be `"INADDR_ANY"` or an identifier for the local device in order to listen
     type: String
   - name: isValid
     summary: whether or not the socket is valid
@@ -88,4 +88,4 @@ properties:
   - name: stripTerminator
     summary: strip terminating null character when sending string data; default is false
     type: Boolean
-description: Sockets are nontrivial; it is recommended that anyone using them be familiar with the basics of BSD sockets.  All sockets use TCP connections, and are asynchronous for read operations, so your program should be ready to receive 'read' events at any point.  Socket references cannot be transferred to socket objects, and vice-versa - socket references are an internal mechanism which is used only to determine which sockets to send data to and read data from.  For listening sockets, it is highly recommended that you use the <Titanium.Network.INADDR_ANY> constant as the host name.  If a window containing a socket is closed, the socket MUST be closed also unless you intend to continue to receive data, otherwise the socket will consume resources (and potentially cause conflicts with opening the window again, if a listener) until the program is restarted.  Be aware of the differences between the listen() and connect() functions; attempting to use one when you mean the other may result in errors, unpredictable behavior, or both.
+description: Sockets are nontrivial; it is recommended that anyone using them be familiar with the basics of BSD sockets.  All sockets use TCP connections, and are asynchronous for read operations, so your program should be ready to receive 'read' events at any point.  Socket references cannot be transferred to socket objects, and vice-versa - socket references are an internal mechanism which is used only to determine which sockets to send data to and read data from.  For listening sockets, it is highly recommended that you use the string `"INADDR_ANY"` as the host name.  If a window containing a socket is closed, the socket MUST be closed also unless you intend to continue to receive data, otherwise the socket will consume resources (and potentially cause conflicts with opening the window again, if a listener) until the program is restarted.  Be aware of the differences between the listen() and connect() functions; attempting to use one when you mean the other may result in errors, unpredictable behavior, or both.

--- a/apidoc/Titanium/UI/Android/Android.yml
+++ b/apidoc/Titanium/UI/Android/Android.yml
@@ -57,11 +57,11 @@ methods:
 
   - name: getColorResource
     summary: |
-        Returns a <Ti.Color> instance for a color defined by the system or user resources (colors.xml)
+        Returns a <Titanium.UI.Color> instance for a color defined by the system or user resources (colors.xml)
     description: |
         This method allows converting a known color resource id or short name to an actual color instance.
 
-        The resource id values can be accessed via <Titanium.Android.R.color> and <Titanium.App.Android.R.color> properties.
+        The resource id values can be accessed via <Titanium.Android.R.color> and `Titanium.App.Android.R.color` properties.
 
         See the official Android Developer documentation for
         the [R.color](https://developer.android.com/reference/android/R.color) constants.

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -862,7 +862,7 @@ examples:
         ```
 ---
 name: disableTabOptions
-summary: Dictionary of options for the <Titanium.UI.TabGroup.disableTabOptions> method.
+summary: Dictionary of options for the <Titanium.UI.TabGroup.disableTabNavigation> method.
 platforms: [android, iphone, ipad, macos]
 since: {android: "12.1.0", iphone: "12.1.0", ipad: "12.1.0", macos: "12.1.0"}
 properties:

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -2320,8 +2320,8 @@ properties:
   - name: SELECTION_STYLE_NONE
     summary: Set the selection style to none.
     description: |
-        Use with the <Titanium.UI.ListView.selectionStyle> and
-        <Titanium.UI.TableView.selectionStyle> properties.
+        Use with the <Titanium.UI.ListItem.selectionStyle> and
+        <Titanium.UI.TableViewRow.selectionStyle> properties.
     type: Number
     permission: read-only
     platforms: [android, iphone, ipad, macos]
@@ -2330,8 +2330,8 @@ properties:
   - name: SELECTION_STYLE_DEFAULT
     summary: Set the selection style to system default.
     description: |
-        Use with the <Titanium.UI.ListView.selectionStyle> and
-        <Titanium.UI.TableView.selectionStyle> properties.
+        Use with the <Titanium.UI.ListItem.selectionStyle> and
+        <Titanium.UI.TableViewRow.selectionStyle> properties.
     type: Number
     permission: read-only
     platforms: [android, iphone, ipad, macos]

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -969,7 +969,7 @@ methods:
 
   - name: clearMotionEffects
     summary: Removes all previously added motion effects.
-    description: Use this method together with <Titanium.UI.horizontalMotionEffect> and <Titanium.UI.verticalMotionEffect>.
+    description: Use this method together with <Titanium.UI.View.horizontalMotionEffect> and <Titanium.UI.View.verticalMotionEffect>.
     since: "8.2.0"
     platforms: [iphone, ipad, macos]
 
@@ -1528,7 +1528,7 @@ properties:
     summary: Adds a horizontal parallax effect to the view
     description: |
         Note that the parallax effect only happens by tilting the device so results can not be seen on Simulator.
-        To clear all motion effects, use the <Titanium.UI.clearMotionEffects> method.
+        To clear all motion effects, use the <Titanium.UI.View.clearMotionEffects> method.
     type: MinMaxOptions
     platforms: [iphone, ipad, macos]
     since: "7.3.0"
@@ -1922,7 +1922,7 @@ properties:
     summary: Adds a vertical parallax effect to the view
     description: |
         Note that the parallax effect only happens by tilting the device so results can not be seen on Simulator.
-        To clear all motion effects, use the <Titanium.UI.clearMotionEffects> method.
+        To clear all motion effects, use the <Titanium.UI.View.clearMotionEffects> method.
     type: MinMaxOptions
     platforms: [iphone, ipad, macos]
     since: "7.3.0"

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -136,8 +136,8 @@ description: |
     You must also call [pause](Titanium.UI.WebView.pause) when the current activity is
     paused, to prevent plugin content from continuing to run in the background. Call
     [resume](Titanium.UI.WebView.resume) when the current activity is resumed. You can
-    do this by adding listeners for the [Activity.pause](Titanium.Android.Activity.pause)
-    and [Activity.resume](Titanium.Android.Activity.resume) events.
+    do this by adding listeners for the <Titanium.Android.Activity.onPause>
+    and <Titanium.Android.Activity.onResume> events.
 
     **Accessing Cookies**
 

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -134,7 +134,7 @@ properties:
         Indicates that the system should present the alert using the standard
         alert style.
     description: |
-        Use with <Titanium.UI.iOS.createAlertDialog> to specify
+        Use with <Titanium.UI.createAlertDialog> to specify
         the alert dialog severity on macOS Catalyst.
     type: Number
     since: "12.0.0"
@@ -146,7 +146,7 @@ properties:
         Indicates that the system should present the alert using the
         critical, or caution, style.
     description: |
-        Use with <Titanium.UI.iOS.createAlertDialog> to specify
+        Use with <Titanium.UI.createAlertDialog> to specify
         the alert dialog severity on macOS Catalyst.
     type: Number
     since: "12.0.0"


### PR DESCRIPTION
33 occurrences of 23 distinct cross-references in `apidoc/` name something that does not exist. They render as dead links on the docs site.

Verified by compiling `apidoc/` with the reference checker and **no allowlist**: 33 unresolved before, **0 after**. Every target was checked against the compiled corpus before being used rather than inferred from the reference's shape — three turned out not to mean what they looked like.

## The member exists, on another type

| referenced | actually declared on |
|---|---|
| `Titanium.UI.{clear,horizontal,vertical}MotionEffect*` | `Titanium.UI.View` |
| `Titanium.UI.ListView.selectionStyle` | `Titanium.UI.ListItem` |
| `Titanium.UI.TableView.selectionStyle` | `Titanium.UI.TableViewRow` |
| `Titanium.UI.iOS.createAlertDialog` | `Titanium.UI` |
| `Titanium.Media.allowMultiple` | `PhotoGalleryOptionsType` |
| `Global.Intl.NumberFormat.NumberFormatOptions.*` | `NumberFormatOptions` |

`disableTabOptions` described itself as "options for the `disableTabOptions` method". The method that takes it is `disableTabNavigation`.

## Real, but never documented

`Titanium.Media.AUDIO_STATE_WAITING_FOR_QUEUE` is referenced from `AudioPlayer`, including in a `deprecated.notes` telling readers to use it instead of the old constant. It exists on both platforms — `MediaModule.m` defines it, and `MediaModule.java:225` gives it value 8 with the comment this summary is taken from. So it is **declared** rather than dropped.

`Titanium.Network.INADDR_ANY` looked like the same case and is the opposite. It is not a constant on the module: `NetworkModule.m` defines `INADDR_ANY_token` as an internal string and the header exposes no such property. Documenting it would have invented an API, so the prose now names the literal string a caller actually passes.

## The target is gone

- `Titanium.Android.Activity.pause`/`resume` — removed in 3.4.0 for the `onPause`/`onResume` properties, which exist, so these point at the replacements rather than losing their link.
- `Titanium.Network.HTTPClient.addAuthFactory` — removed from the JS API in 5.0.0. It survives as a plain Java method on `TiHTTPClient` with no `@Kroll` annotation, so an app cannot call it. The sentence claiming Android could be extended through it is replaced with what Android actually does; **worth a maintainer's eye**, as it is the one edit that asserts something new rather than removing a dead link.
- `Ti.Color` — not a type; colors are strings.
- `Titanium.App.Android.R` — no documented members. `Titanium.Android.R.color` does have them and keeps its link.
- `Titanium.Geolocation.frequency`, `preferredProvider` — removed.
- `fs.rmDir` is really `fs.rmdir`; `fs.rm` and `fs.rmDirSync` do not exist; `fs.Dir` is not a type — `fs.readdir` is what returns directory entries.

Documentation only, no behaviour change. 12 files, 35 insertions, 29 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)