### PR TITLE
fix(ios): allow TableViewRow height of 0 to collapse the row

### DIFF
--- a/apidoc/Titanium/UI/TableViewRow.yml
+++ b/apidoc/Titanium/UI/TableViewRow.yml
@@ -39,6 +39,10 @@ description: |
     The `top`, `left` and other positional parameters are not used for their usual purposes, because
     the table view row is automatically positioned by its parent.
 
+    On iOS, setting `height` to `0` collapses the row so it takes up no space in the table. A row
+    that is not given a `height` still falls back to the table's [rowHeight](Titanium.UI.TableView.rowHeight),
+    and the table's [minRowHeight](Titanium.UI.TableView.minRowHeight) is still applied to a `0` height.
+
     On Android, these properties are used to position the content (title) inside the row. For example,
     setting `top` to 20 moves the title down from the top of the row.
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -393,7 +393,7 @@
   if (TiDimensionIsDip(maxRowHeight)) {
     height = MIN(maxRowHeight.value, height);
   }
-  return height < 1 ? tableview.rowHeight : height;
+  return height < 0 ? tableview.rowHeight : height;
 }
 
 // Allows use of scrollsToTop property on a table.
@@ -2746,7 +2746,7 @@
   CGFloat width = [row sizeWidthForDecorations:[self computeRowWidth] forceResizing:YES];
   CGFloat height = [row rowHeight:width];
   height = [self tableRowHeight:height];
-  return height < 1 ? tableview.rowHeight : height;
+  return height < 0 ? tableview.rowHeight : height;
 }
 
 - (UIView *)tableView:(UITableView *)ourTableView viewForHeaderInSection:(NSInteger)section

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -306,7 +306,9 @@ TiProxy *DeepScanForProxyOfViewContainingPoint(UIView *targetView, CGPoint point
   result = [(TiLayoutView *)[self currentRowContainerView] heightIfWidthWere:width];
   result = result == 0 ? 0 : result + 1;
 #endif
-  return (result == 0) ? [table tableRowHeight:0] : result;
+  // 0 is a real height now (an explicit height:0 collapses the row), so ask the
+  // table for its default with a negative sentinel rather than 0.
+  return (result == 0) ? [table tableRowHeight:-1] : result;
 }
 
 - (void)updateRow:(NSDictionary *)data withObject:(NSDictionary *)properties
@@ -691,6 +693,9 @@ TiProxy *DeepScanForProxyOfViewContainingPoint(UIView *targetView, CGPoint point
       [rowContainerView setFrame:rect];
       [contentView addSubview:rowContainerView];
     }
+    // Keep children inside the row bounds, otherwise a collapsed (height:0)
+    // or shrunken row still draws its content over the neighbouring rows.
+    [rowContainerView setClipsToBounds:YES];
 #ifdef TI_USE_AUTOLAYOUT
     [rowContainerView performSelector:@selector(updateWidthAndHeight)];
 #endif

--- a/tests/Resources/ti.ui.tableview.test.js
+++ b/tests/Resources/ti.ui.tableview.test.js
@@ -1532,6 +1532,37 @@ describe('Titanium.UI.TableView', function () {
 		win.open();
 	});
 
+	it.ios('row with height 0 takes no space', function (finish) {
+		if (isCI && utilities.isMacOS()) { // FIXME: see row#rect above
+			return finish();
+		}
+
+		win = Ti.UI.createWindow();
+
+		const tableView = Ti.UI.createTableView();
+		const hiddenRow = Ti.UI.createTableViewRow({
+			height: 0,
+			title: 'hidden'
+		});
+		const visibleRow = Ti.UI.createTableViewRow({
+			title: 'visible'
+		});
+
+		tableView.data = [ hiddenRow, visibleRow ];
+
+		hiddenRow.addEventListener('postlayout', () => {
+			try {
+				should(hiddenRow.rect.height).be.eql(0);
+			} catch (e) {
+				return finish(e);
+			}
+			finish();
+		});
+
+		win.add(tableView);
+		win.open();
+	});
+
 	it('rows with vertical or horizontal layout', finish => {
 		win = Ti.UI.createWindow();
 


### PR DESCRIPTION
Currently it is not possible on iOS to have a `height:0` TableViewRow to hide it (Android works fine).

**Test code**

```js
const win = Ti.UI.createWindow();

function createRow(text, height) {
  const row = Ti.UI.createTableViewRow({ height: height });
  row.add(Ti.UI.createLabel({ text: text, left: 16 }));
  return row;
}

const tableView = Ti.UI.createTableView({
  data: [
    createRow('Row 1', 40),
    createRow('Row 2', 0),  // <---- 0
    createRow('Row 3', 40),
    createRow('Row 4', 40)
  ]
});

win.add(tableView);
win.open();
```

**13.4.1** 

Android:
<img width="480" height="241" alt="Screenshot_20260912-190857" src="https://github.com/user-attachments/assets/31d86680-e024-4af5-9f3f-8bceb4903f0d" />

iOS:

<img width="480" height="325" alt="Simulator Screenshot - iPhone 17e - 2026-09-12 at 19 11 15" src="https://github.com/user-attachments/assets/01fdb53d-d4cb-4a45-8deb-592c9375ae9d" />

**With this PR:**

iOS:

<img width="480" height="236" alt="Simulator Screenshot - iPhone 17e - 2026-09-12 at 19 16 59" src="https://github.com/user-attachments/assets/42eb72fc-30ca-41a9-973d-7e7bde90163f" />

