### PR TITLE
fix(android): apply theme's light system bar attributes to window

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -65,6 +65,7 @@ import android.content.IntentSender;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
+import android.content.res.TypedArray;
 import android.graphics.Insets;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
@@ -551,6 +552,37 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		}
 	}
 
+	/**
+	 * Applies the theme's "android:windowLightStatusBar" and "android:windowLightNavigationBar"
+	 * attributes to the window's system bar appearance.
+	 * <p>
+	 * The OS only applies these via legacy "systemUiVisibility" flags, which are ignored once the
+	 * WindowInsetsController has been used. With edge-to-edge, a light theme could then end up with
+	 * light icons over a light background (seen with bottom navigation TabGroups on Android 15+).
+	 * Called before the Window/TabGroup proxy's windowCreated() so its properties still win.
+	 */
+	protected void applyThemeSystemBarAppearance()
+	{
+		// Note: Attribute IDs must be in ascending order.
+		final TypedArray typedArray = getTheme().obtainStyledAttributes(new int[] {
+			android.R.attr.windowLightStatusBar,
+			android.R.attr.windowLightNavigationBar
+		});
+		try {
+			final Window window = getWindow();
+			final WindowInsetsControllerCompat insetsController = WindowCompat
+				.getInsetsController(window, window.getDecorView());
+			if (typedArray.hasValue(0)) {
+				insetsController.setAppearanceLightStatusBars(typedArray.getBoolean(0, false));
+			}
+			if (typedArray.hasValue(1)) {
+				insetsController.setAppearanceLightNavigationBars(typedArray.getBoolean(1, false));
+			}
+		} finally {
+			typedArray.recycle();
+		}
+	}
+
 	// Subclasses can override to handle post-creation (but pre-message fire) logic
 	protected void windowCreated(Bundle savedInstanceState)
 	{
@@ -640,6 +672,9 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 			Log.d(TAG, "windowSoftInputMode: " + softInputMode, Log.DEBUG_MODE);
 			getWindow().setSoftInputMode(softInputMode);
 		}
+
+		// Apply the theme's light/dark system bar icon settings before the proxy can override them.
+		applyThemeSystemBarAppearance();
 
 		// If this activity was created by a Window/TabGroup proxy, then give it this activity's reference.
 		int windowId = getIntentInt(TiC.INTENT_PROPERTY_WINDOW_ID, TiActivityWindows.INVALID_WINDOW_ID);


### PR DESCRIPTION
With edge-to-edge on Android 15+, the theme's windowLightStatusBar and windowLightNavigationBar attributes could be ignored, leaving light status bar icons over a light background (seen with bottom navigation TabGroups). Apply them via WindowInsetsControllerCompat before the proxy's windowCreated().

<img width="640" height="128" alt="Screenshot_20260913-133506" src="https://github.com/user-attachments/assets/35802a15-6edb-4cd2-b4d1-8d5d8a6242ab" />

white text/icons on bright backgorundColor; Android 13. Android 17 is fine.

TabGroup has a light backgroundColor and this is in my theme:
```xml
<item name="android:windowLightStatusBar">true</item>
```

After this PR Android 13 will be correct:
<img width="640" height="121" alt="Screenshot_20260913-133937" src="https://github.com/user-attachments/assets/5556e3f2-b538-4754-b38d-e6af86a120b2" />
